### PR TITLE
🐛 fix: Move 404 page route to top-level for proper fallback

### DIFF
--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -19,13 +19,12 @@ function AppRouter() {
     <Router>
       <Routes>
         <Route path="/" element={<Navigate to={`/${year}/${month}/home`} />} />
-
         <Route path="/:year/:month" element={<App />}>
           <Route path="home" element={<HomePage />} />
           <Route path="calendar" element={<CalendarPage />} />
           <Route path="stats" element={<StatsPage />} />
-          <Route path="*" element={<NotFoundPage />} />
         </Route>
+        <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </Router>
   );


### PR DESCRIPTION
## 작업 완료 내역

### 🐛 버그 수정  
- **404 Not Found 페이지가 최상위 라우터에서 작동하지 않던 문제 해결**  
  - 기존에는 `/:year/:month` 경로 아래에 404 페이지 라우트를 작성하여, 상위 경로(`/`, `/calendar`, `/stats` 등) 접근 시 404 처리가 되지 않음  
  - 404 라우트를 **최상위 위치로 이동**하여 모든 경로에서 올바르게 작동하도록 수정  

---

## 주요 고민 및 해결과정

### 문제
초기에는 `404 Not Found` 라우트를 `/:year/:month` 그룹 아래에 작성했기 때문에, `/404`가 아닌 다른 잘못된 최상위 경로(`/invalid`, `/wrong/path`)로 접근할 경우, 라우터가 이를 인식하지 못하고 아무 화면도 보여주지 않는 문제가 발생했습니다.

```jsx
 <Router>
      <Routes>
        <Route path="/" element={<Navigate to={`/${year}/${month}/home`} />} />
        <Route path="/:year/:month" element={<App />}>
           //... 그외 라우트 페이지
          <Route path="*" element={<NotFoundPage />} />     // << App 라우트 하위 레벨(잘못된 위치)
        </Route>
      </Routes>
    </Router>
```

### 해결
이를 해결하기 위해 **라우터 트리에서 최하단에 위치한 별도 Route를 최상위에 배치**하여 모든 경로에서 404 처리가 정상 작동하도록 구조를 수정하였습니다.  
이제 `/home/:year/:month` 외 모든 예외 경로에 대해 404 페이지가 잘 렌더링됩니다.

```jsx
  <Router>
      <Routes>
        <Route path="/" element={<Navigate to={`/${year}/${month}/home`} />} />
        <Route path="/:year/:month" element={<App />}>
             //... 그외 라우트 페이지
        </Route>
        <Route path="*" element={<NotFoundPage />} />   // << 최상위로 이동
      </Routes>
    </Router>
```