### PR TITLE
♻️ refactor: Update route paths to /page/:year/:month format

### DIFF
--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -5,15 +5,11 @@ import AppRouter from './router.jsx';
 import globalStyle from './theme/globalStyle';
 import theme from './theme/theme';
 
-import App from './App.jsx';
-
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <ThemeProvider theme={theme}>
       <Global styles={globalStyle} />
-      <AppRouter>
-        <App />
-      </AppRouter>
+      <AppRouter />
     </ThemeProvider>
   </StrictMode>
 );

--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -17,15 +17,21 @@ function AppRouter() {
   const { year, month } = getYearMonth(new Date());
   const initialUrl = buildUrlWithPage(year, month, 'home');
 
+  console.log(initialUrl);
+
   return (
     <Router>
       <Routes>
-        <Route path="/" element={<Navigate to={initialUrl} />} />
-        <Route path="/:year/:month" element={<App />}>
-          <Route path="home" element={<HomePage />} />
-          <Route path="calendar" element={<CalendarPage />} />
-          <Route path="stats" element={<StatsPage />} />
+        {/* 초기 페이지 랜더링시*/}
+        <Route path="/" element={<Navigate to={initialUrl} replace />} />
+
+        {/* 그 이후에 App 진입 시 라우팅 */}
+        <Route path="/" element={<App />}>
+          <Route path="home/:year/:month" element={<HomePage />} />
+          <Route path="calendar/:year/:month" element={<CalendarPage />} />
+          <Route path="stats/:year/:month" element={<StatsPage />} />
         </Route>
+
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     </Router>

--- a/src/features/header/hooks/useMonthNavigator.js
+++ b/src/features/header/hooks/useMonthNavigator.js
@@ -18,7 +18,8 @@ function useMonthNavigator() {
     const updatedYear = updatedDate.getFullYear();
     const updatedMonth = String(updatedDate.getMonth() + 1).padStart(2, '0');
 
-    const pagePath = pathname.split('/').slice(3).join('/');
+    const segments = pathname.split('/').filter(Boolean);
+    const pagePath = segments[0];
     return buildUrlWithPage(updatedYear, updatedMonth, pagePath);
   };
 

--- a/src/features/header/hooks/usePageNavigator.js
+++ b/src/features/header/hooks/usePageNavigator.js
@@ -19,7 +19,7 @@ export default function usePageNavigator() {
       throw new Error(`Invalid page type: ${pageType}`);
     }
 
-    navigate(`/${currentYear}/${currentMonth}/${pageType}`);
+    navigate(`/${pageType}/${currentYear}/${currentMonth}`);
   };
 
   return { navigateTo };

--- a/src/shared/utils/buildUrlWithPage.js
+++ b/src/shared/utils/buildUrlWithPage.js
@@ -1,4 +1,4 @@
 export default function buildUrlWithPage(year, month, page) {
   const paddedMonth = String(month).padStart(2, '0');
-  return `/${year}/${paddedMonth}/${page}`;
+  return `/${page}/${year}/${paddedMonth}`;
 }

--- a/src/shared/utils/getActiveTabFromPath.js
+++ b/src/shared/utils/getActiveTabFromPath.js
@@ -1,3 +1,3 @@
 export function getActiveTabFromPath(pathname) {
-  return pathname.split('/').at(-1);
+  return pathname.split('/').filter(Boolean)[0];
 }


### PR DESCRIPTION
## 완료 작업 목록
- 라우팅 경로 /page/:year/:month 으로 변경

## 주요 고민과 해결과정

이번 헤더 기능 구현 과정에서는 라우팅 구조 변경을 병행하면서 여러 이슈를 경험하였고, 이를 해결하는 과정에서 다음과 같은 흐름을 따랐습니다.

#### 목표

- 기존 경로: `/:year/:month/:page`
- 변경 목표: `/page/:year/:month` → 후에 `/home/:year/:month`로 확정
- `/`로 진입 시 자동으로 `/home/:year/:month`로 이동
- `<App />`은 공통 레이아웃으로 사용, `Outlet`으로 페이지 분기

---

### 1.문제: 기본 경로로 진입해도 URL이 바뀌지 않음

#### 증상

- 브라우저 주소가 `/` 그대로 유지
- `/home/:year/:month`로 리디렉션이 되지 않음
- 콘솔에 `Navigate` 실행 로그는 있으나 URL 변화 없음

#### 원인 분석

```jsx
<AppRouter>
  <App />  // ❌ React Router의 제어 밖에서 직접 렌더링됨
</AppRouter>
```

- 위와 같이 `<App />`을 JSX로 직접 사용하면 Route에서 지정한 `<Navigate>`는 작동하지 않음

#### 해결 방법

- `<App />`은 JSX에서 직접 호출하지 않고, 반드시 `<Route element={<App />}>` 방식으로만 렌더링하도록 수정

---

### 2.문제: Navigate가 있어도 useParams()가 undefined

#### 증상

- `<App />`에서 `useParams()` 값이 undefined
- `useFetchRecordsByDate(year, month)`에서 무한 로딩 상태 유지

#### 원인 분석

```jsx
<Route path="/" element={<App />}>
  <Route index element={<Navigate to="/home/2025/04" />} />
```

- 위 구조에선 `<App />`이 먼저 렌더링됨 → 이 시점에 params는 없음
- 이후 index route가 렌더링되며 Navigate 실행 → 타이밍 문제 발생

#### 해결 방법

```jsx
<Route path="/" element={<Navigate to={`/home/${year}/${month}`} replace />} />
<Route path="/" element={<App />}>...</Route>
```

- 루트 경로 `/`에 대한 리디렉션을 `<App />` 바깥에서 먼저 처리
- 이후부터는 params가 항상 존재한 상태로 `<App />`이 렌더링됨

---

## 최종 구조 요약

### AppRouter.jsx

```jsx
<Routes>
  <Route path="/" element={<Navigate to={`/home/${year}/${month}`} replace />} />
  <Route path="/" element={<App />}>
    <Route path="home/:year/:month" element={<HomePage />} />
    <Route path="calendar/:year/:month" element={<CalendarPage />} />
    <Route path="stats/:year/:month" element={<StatsPage />} />
  </Route>
  <Route path="*" element={<NotFoundPage />} />
</Routes>
```
