### PR TITLE
♻️  refactor: apply reducer-based state for global records

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useParams, useLocation, Outlet } from 'react-router-dom';
-import useFetchRecordsByDate from '../shared/hooks/useFetchRecordsByDate';
+import useRecordState from '../shared/hooks/useRecordState';
 import { getActiveTabFromPath } from '../shared/utils/getActiveTabFromPath';
 import Header from '../features/header';
 
@@ -17,7 +17,7 @@ const Content = styled.main`
 
 function App() {
   const { year, month } = useParams();
-  const { data, loading } = useFetchRecordsByDate(year, month);
+  const { records, dispatch, loading, error } = useRecordState(year, month);
 
   const { pathname } = useLocation();
   const activeTab = getActiveTabFromPath(pathname);
@@ -28,9 +28,9 @@ function App() {
 
   return (
     <LayoutWrapper>
-      <Header year={data.year} month={data.month} activeTab={activeTab} />
+      <Header year={year} month={month} activeTab={activeTab} />
       <Content>
-        <Outlet context={{ data }} />
+        <Outlet context={{ records, dispatch }} />
       </Content>
     </LayoutWrapper>
   );

--- a/src/pages/CalendarPage.jsx
+++ b/src/pages/CalendarPage.jsx
@@ -1,13 +1,9 @@
 import { useOutletContext } from 'react-router-dom';
 
 function CalendarPage() {
-  const { data } = useOutletContext();
+  const { records } = useOutletContext();
 
-  return (
-    <div>
-      달력 페이지입니다. 날짜는 {data.year}.{data.month}
-    </div>
-  );
+  return <div>달력 페이지입니다. 내역 개수는 {records.length}</div>;
 }
 
 export default CalendarPage;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,13 +1,9 @@
 import { useOutletContext } from 'react-router-dom';
 
 function HomePage() {
-  const { data } = useOutletContext();
+  const { records } = useOutletContext();
 
-  return (
-    <div>
-      기본 페이지입니다. 날짜는 {data.year}.{data.month}
-    </div>
-  );
+  return <div>기본 페이지입니다. 내역 개수는 {records.length}</div>;
 }
 
 export default HomePage;

--- a/src/pages/StatsPage.jsx
+++ b/src/pages/StatsPage.jsx
@@ -1,13 +1,9 @@
 import { useOutletContext } from 'react-router-dom';
 
 function StatsPage() {
-  const { data } = useOutletContext();
+  const { records } = useOutletContext();
 
-  return (
-    <div>
-      통계 페이지입니다. 날짜는 {data.year}.{data.month}
-    </div>
-  );
+  return <div>통계 달력 페이지입니다. 내역 개수는 {records.length}</div>;
 }
 
 export default StatsPage;

--- a/src/shared/hooks/useRecordState.js
+++ b/src/shared/hooks/useRecordState.js
@@ -1,0 +1,16 @@
+import { useReducer, useEffect } from 'react';
+import useFetchRecordsByDate from './useFetchRecordsByDate';
+import recordReducer from '../reducers/recordReducer';
+
+export default function useRecordState(year, month) {
+  const { data, loading, error } = useFetchRecordsByDate(year, month);
+  const [records, dispatch] = useReducer(recordReducer, []);
+
+  useEffect(() => {
+    if (data?.records.length > 0) {
+      dispatch({ type: 'SET_RECORDS', payload: data.records });
+    }
+  }, [data]);
+
+  return { records, dispatch, loading, error };
+}

--- a/src/shared/reducers/recordReducer.js
+++ b/src/shared/reducers/recordReducer.js
@@ -1,0 +1,18 @@
+export default function recordReducer(state, action) {
+  switch (action.type) {
+    case 'SET_RECORDS':
+      return action.payload;
+    case 'ADD_RECORD':
+      return [...state, action.payload];
+    case 'UPDATE_RECORD':
+      return state.map((record) =>
+        record.id === action.payload.id
+          ? { ...record, ...action.payload }
+          : record
+      );
+    case 'DELETE_RECORD':
+      return state.filter((record) => record.id !== action.payload);
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
## 완료 작업 목록
### ♻️ 리팩토링
- records 상태관리를 위한 **리듀서 구조** 도입 및 전역 적용
  - records 상태 관리를 위한 리듀서 구조를 도입
  - 커스텀 훅을 통해 리듀서 및 dispatch 로직 구현
  - 각 페이지에 새 상태 관리 구조를 전역적으로 적용

## 주요 고민 및 해결과정

### 1. 데이터 패칭 이후 로컬 상태 조작을 위한 안정적인 상태관리 구조 정립

### 문제의 배경

초기에는 `useFetchRecordData` 커스텀 훅을 통해 데이터를 가져오고,  
`data`, `loading`, `error` 상태만을 반환하는 방식으로 설계했으나,  
시간이 지나며 레코드의 생성, 수정, 삭제 기능이 필요해졌다.

이를 위해 상태를 조작할 수 있는 `setData` 같은 setter가 필요했지만,  
이는 상태 로직이 뷰에 노출되고, 각기 다른 컴포넌트에서 복잡한 객체 조작 및 순회가 발생하였습니다하는 구조가 되었다.

상태 관리의 일관성과 뷰와의 분리를 위해 `reducer` 기반의 설계로 변경하기로 결정하였습니다.


### 구조 설계

구조는 다음과 같이 3단계로 나누어 설계하였습니다.

- `useFetchRecordsByDate`  
  fetch 전용 훅. 데이터를 받아오는 역할만 수행합니다

- `recordReducer.js`  
  상태 업데이트 규칙 정의 (SET, ADD, UPDATE, DELETE)

- `useRecordState`  
  위 두 기능을 결합. 초기 상태를 fetch로 세팅하고 이후에는 dispatch를 통해 조작

```txt
[App]
 ├ useRecordState → records + dispatch 제공
 └ Outlet context로 하위 페이지에 전달
```

### 데이터 fetch 로직 분리에 대한 고민

초기에는 `useRecordState` 내부에 `fetch` 로직과 `reducer` 상태 초기화 로직을 함께 두었으나,  
점차적으로 다음과 같은 문제 의식이 생겼습니다.

- 데이터 요청(fetch)과 상태 조작(dispatch)의 역할이 혼재되어 단일 책임 원칙이 모호해짐
- 향후 다른 페이지나 훅에서도 fetch 로직을 재사용할 가능성이 있음
- 테스트 또는 유지보수 시 네트워크 로직과 상태 로직을 따로 분리할 필요가 있음

이러한 이유로 `fetch` 관련 로직은 `useFetchRecordsByDate`라는 별도의 훅으로 분리하고,  
`useRecordState`는 순수하게 상태 관리 및 상태 초기화(dispatch)만 담당하도록 역할을 명확히 하였습니다.

이 구조적 분리는 추후 서버 연동 및 에러 처리, 낙관적 업데이트 등도 유연하게 대응할 수 있는 기반이 됩니다.

---

### 에러 1: data가 null인데 length를 참조함

처음에 `data`가 null이므로 `data.length` 접근 시 다음과 같은 에러 발생하였습니다:

```
TypeError: Cannot read properties of null (reading 'length')
```

#### 해결 방법

옵셔널 체이닝을 사용하여 null을 방지:

```js
if (data?.length > 0) {
  ...
}
```

그러나 이 방식도 문제가 있었음 — `data`는 배열이 아니라 객체였기 때문

### 에러 2: data는 객체인데 length 접근 → 조건문이 통과되지 않음

데이터 형태는 다음과 같음:

```js
{
  year: '2025',
  month: '04',
  records: [ ... ]
}
```

`data.length` 또는 `data?.length`는 undefined이므로  
`SET_RECORDS`가 호출되지 않음 → reducer는 초기 상태만 유지됩니다

#### 최종 해결

다음과 같이 정확히 `records` 배열의 length를 확인:

```js
if (data?.records?.length > 0) {
  dispatch({ type: 'SET_RECORDS', payload: data.records });
}
```



