### PR TITLE
♻️  refactor: separate layout and data logic via Content component

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,8 +1,5 @@
 import styled from '@emotion/styled';
-import { useEffect } from 'react';
-import { useParams, Outlet } from 'react-router-dom';
-import useFetchRecordsByDate from '../shared/hooks/useFetchRecordsByDate';
-import useRecordState from '../shared/hooks/useRecordState';
+import Content from './Content';
 import Header from '../features/header';
 
 const LayoutWrapper = styled.div`
@@ -12,31 +9,11 @@ const LayoutWrapper = styled.div`
   min-height: 100vh;
 `;
 
-const Content = styled.main`
-  flex: 1;
-`;
-
 function App() {
-  const { year, month } = useParams();
-  const { data: fetchedData, loading } = useFetchRecordsByDate(year, month);
-  const { records, dispatch } = useRecordState();
-
-  useEffect(() => {
-    if (!loading && fetchedData) {
-      dispatch({ type: 'SET_RECORDS', payload: fetchedData });
-    }
-  }, [loading, fetchedData]);
-
   return (
     <LayoutWrapper>
       <Header />
-      <Content>
-        {loading ? (
-          <div>loading...</div>
-        ) : (
-          <Outlet context={{ records, dispatch }} />
-        )}
-      </Content>
+      <Content />
     </LayoutWrapper>
   );
 }

--- a/src/app/Content.jsx
+++ b/src/app/Content.jsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+import { useParams, Outlet } from 'react-router-dom';
+import { useEffect } from 'react';
+import useFetchRecordsByDate from '../shared/hooks/useFetchRecordsByDate';
+import useRecordState from '../shared/hooks/useRecordState';
+
+const ContentWrapper = styled.main`
+  flex: 1;
+`;
+
+export default function Content() {
+  const { year, month } = useParams();
+  const { data: fetchedData, loading } = useFetchRecordsByDate(year, month);
+  const { records, dispatch } = useRecordState(fetchedData);
+
+  useEffect(() => {
+    if (!loading && fetchedData) {
+      dispatch({ type: 'SET_RECORDS', payload: fetchedData });
+    }
+  }, [loading, fetchedData]);
+
+  return (
+    <ContentWrapper>
+      {loading ? (
+        <div>loading...</div>
+      ) : (
+        <Outlet context={{ records, dispatch }} />
+      )}
+    </ContentWrapper>
+  );
+}

--- a/src/app/router.jsx
+++ b/src/app/router.jsx
@@ -12,6 +12,7 @@ import CalendarPage from '../pages/CalendarPage';
 import StatsPage from '../pages/StatsPage';
 import NotFoundPage from '../pages/NotFoundPage';
 import App from './App';
+import Content from './Content';
 
 function AppRouter() {
   const { year, month } = getYearMonth(new Date());
@@ -27,9 +28,11 @@ function AppRouter() {
 
         {/* 그 이후에 App 진입 시 라우팅 */}
         <Route path="/" element={<App />}>
-          <Route path="home/:year/:month" element={<HomePage />} />
-          <Route path="calendar/:year/:month" element={<CalendarPage />} />
-          <Route path="stats/:year/:month" element={<StatsPage />} />
+          <Route element={<Content />}>
+            <Route path="home/:year/:month" element={<HomePage />} />
+            <Route path="calendar/:year/:month" element={<CalendarPage />} />
+            <Route path="stats/:year/:month" element={<StatsPage />} />
+          </Route>
         </Route>
 
         <Route path="*" element={<NotFoundPage />} />


### PR DESCRIPTION
## 완료 작업 목록
### 기존 `App.jsx`에서 담당하던 다음의 로직을 `Content.jsx`로 이동
- URL 파라미터(`year`, `month`) 추출
- 해당 월의 데이터 fetch
- 로딩 상태 처리
- 상태 초기화 (`dispatch`로 SET_RECORDS)
- `Outlet`에 `records`, `dispatch` 전달

## 주요 고민과 해결과정

### App → Content 구조로 리팩토링한 라우팅 계층 정리

#### 문제의 배경

초기에는 `App` 컴포넌트가 다음과 같은 **두 가지 책임**을 모두 갖고 있었습니다.

- 전체 레이아웃 구성 (헤더, 페이지 구조)
- 데이터 패칭 및 상태 관리 (연월에 따른 records fetch)

이로 인해 컴포넌트의 책임이 모호해지고, 유지보수 시 다음과 같은 문제가 발생했습니다:

- `App`의 UI 변경 시 데이터 로직에도 영향을 줄 수 있음
- 테스트 및 기능 확장이 어려움 (예: 다른 페이지에서도 records를 재사용할 때)
- 리팩토링 시 레이아웃과 상태 로직이 뒤엉켜 응집도가 낮음


#### 리팩토링 의도: 단일 책임 원칙(SRP)

- `App`은 **오직 레이아웃만 담당**하는 컴포넌트로 남기고
- 데이터 패칭(fetch) 및 Outlet 전달은 **`Content`라는 중간 계층**으로 분리

---

## 리팩토링 중 발생한 문제

### 문제 1: Header가 화면에 나타나지 않음
- `App` 내부의 `<Header />`는 정상적으로 렌더링되었으나
- 라우터 구조상 `App → Content → Outlet`이 되지 않고, `Content`만 렌더링되었음

#### 원인 분석
- `Content`가 `path="/"`를 가지고 있어서 `App`과 path가 중복됨
- 이로 인해 `App`이 아예 렌더링되지 않고, `Content`만 렌더링됨


### 문제 2: Outlet으로 데이터가 전달되지 않음
- `Content`에서 `useParams`로 연월을 받아 fetch하고, reducer로 상태 초기화 후
- `Outlet context={{ records, dispatch }}`로 전달했으나 하위 페이지에서 접근이 불가했음

#### 원인 분석
- 라우팅 트리에서 `Content`가 path 없이 선언되지 않아, 중간 Outlet 계층으로 인식되지 않음
- `App` → `Content` → `HomePage`의 라우팅 구조가 형성되지 못함

## 해결 방법

1. 라우터 구조를 다음처럼 재구성하여 `Content`는 path 없이 중간 계층으로 선언:

```jsx
<Route path="/" element={<App />}>
  <Route element={<Content />}>
    <Route path="home/:year/:month" element={<HomePage />} />
    <Route path="calendar/:year/:month" element={<CalendarPage />} />
    <Route path="stats/:year/:month" element={<StatsPage />} />
  </Route>
</Route>
```

2. `App`은 항상 렌더링되고, `Header`도 유지됨
3. `Content`는 중간 계층에서 fetch 후 context로 데이터를 내려줌
4. 각 페이지(HomePage 등)는 `useOutletContext()`로 `records`, `dispatch` 접근 가능
