### PR TITLE
♻️  refactor: decouple form logic from state handling in record reducer

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -47,45 +47,31 @@ function HomePage() {
     };
   };
 
-  const addRecordIfCurrentMonth = (record, isNowInCurrentMonth) => {
-    if (isNowInCurrentMonth) {
-      recordDataDispatch({ type: 'ADD_RECORD', payload: record });
-    }
-  };
-
-  const updateRecordIfCurrentMonth = (record, isNowInCurrentMonth) => {
-    if (isNowInCurrentMonth) {
-      recordDataDispatch({ type: 'UPDATE_RECORD', payload: record });
-    } else {
-      recordDataDispatch({ type: 'DELETE_RECORD', payload: record.id });
-    }
-  };
-
   const handleSubmit = async () => {
+    const validationResult = recordSchema.safeParse(formData);
+    if (!validationResult.success) return;
+
     const isEditMode = originalFormData !== null;
-    const isNowInCurrentMonth = isSameYearMonth(
+
+    const isInCurrentMonth = isSameYearMonth(
       currentYear,
       currentMonth,
       formData.date
     );
 
-    const validationResult = recordSchema.safeParse(formData);
-    if (!validationResult.success) return;
+    const record = buildRecordToSend(formData, isEditMode); //TODO 추후 서버로 오는 resonse.data 사용 시 buildRecordToSend 함수 제거
 
     try {
-      const recordToSend = buildRecordToSend(formData, isEditMode); //TODO 추후 서버로 오는 resonse.data 사용 시 buildRecordToSend 함수 제거
-
       // TODO 서버 api 추가
       // const response = isEditMode
       //   ? await patchRecordToServer(recordToSend)
       //   : await postRecordToServer(recordToSend);
       // const savedRecord = response.data;
 
-      if (isEditMode) {
-        updateRecordIfCurrentMonth(recordToSend, isNowInCurrentMonth); // TODO 서버 연결 시 recordToSend 대신 savedRecord 사용
-      } else {
-        addRecordIfCurrentMonth(recordToSend, isNowInCurrentMonth);
-      }
+      recordDataDispatch({
+        type: isEditMode ? 'UPDATE_RECORD' : 'ADD_RECORD',
+        payload: { record, isInCurrentMonth },
+      });
 
       handleReset();
     } catch (error) {

--- a/src/shared/hooks/useRecordState.js
+++ b/src/shared/hooks/useRecordState.js
@@ -5,16 +5,30 @@ function recordReducer(state, action) {
   switch (action.type) {
     case 'SET_RECORDS':
       return action.payload;
-    case 'ADD_RECORD':
-      return [...state, action.payload];
-    case 'UPDATE_RECORD':
-      return state.map((record) =>
-        record.id === action.payload.id
-          ? { ...record, ...action.payload }
-          : record
-      );
-    case 'DELETE_RECORD':
-      return state.filter((record) => record.id !== action.payload);
+    case 'ADD_RECORD': {
+      const { record: newRecord, isInCurrentMonth } = action.payload;
+      return isInCurrentMonth ? [...state, newRecord] : state;
+    }
+    case 'UPDATE_RECORD': {
+      const { record: updatedRecord, isInCurrentMonth } = action.payload;
+      const exists = state.some((record) => record.id === updatedRecord.id);
+
+      if (!isInCurrentMonth && exists) {
+        // 날짜가 다른 달로 바뀌었으면 삭제
+        return state.filter((record) => record.id !== updatedRecord.id);
+      }
+      if (isInCurrentMonth && exists) {
+        // 같은 달이면 업데이트
+        return state.map((record) =>
+          record.id === updatedRecord.id ? updatedRecord : record
+        );
+      }
+      return state;
+    }
+    case 'DELETE_RECORD': {
+      const idToDelete = action.payload;
+      return records.filter((prevRecord) => prevRecord.id !== idToDelete);
+    }
     default:
       return state;
   }


### PR DESCRIPTION
## 완료 작업 목록

### ♻️  refactor : handleSubmit 함수의 책임 단순화

- handleSubmit 함수의 책임을 단순화
→ 유효성 검사, 레코드 생성, 리듀서 디스패치, 리셋만 수행하도록 정리

- isSameYearMonth로 현재 월 여부 판단 후, 리듀서에 결과 전달
- 리듀서에서 ADD_RECORD, UPDATE_RECORD, DELETE_RECORD 처리 방식 변경
→ 현재 월 여부에 따라 레코드를 상태에 추가/수정/삭제

- 액션 payload 구조 변경
→ payload: { record, isInCurrentMonth } 형태로 전달

- 분기 함수(addRecordIfCurrentMonth, updateRecordIfCurrentMonth) 제거
- buildRecordToSend 함수는 그대로 유지하여 record 생성 책임 분리
- 향후 확장을 고려한 구조로 개선

## 주요 고민과 해결 과정

### Record 상태 관리 리팩토링

### 리팩토링 전 구조

초기 `handleSubmit` 함수는 다음과 같이 여러 책임이 하나에 몰려 있는 구조였습니다.

```js
const buildRecordToSend = (formData, isEditMode) => {
  return {
    ...formData,
    id: isEditMode ? formData.id : uuidv4(),
    createdAt: isEditMode ? formData.createdAt : getTimestamp(new Date()),
  };
};

const addRecordIfCurrentMonth = (record, isNowInCurrentMonth) => {
  if (isNowInCurrentMonth) {
    recordDataDispatch({ type: 'ADD_RECORD', payload: record });
  }
};

const updateRecordIfCurrentMonth = (record, isNowInCurrentMonth) => {
  if (isNowInCurrentMonth) {
    recordDataDispatch({ type: 'UPDATE_RECORD', payload: record });
  } else {
    recordDataDispatch({ type: 'DELETE_RECORD', payload: record.id });
  }
};

const handleSubmit = async () => {
  const isEditMode = originalFormData !== null;
  const isNowInCurrentMonth = isSameYearMonth(
    currentYear,
    currentMonth,
    formData.date
  );

  const validationResult = recordSchema.safeParse(formData);
  if (!validationResult.success) return;

  try {
    const recordToSend = buildRecordToSend(formData, isEditMode);

    if (isEditMode) {
      updateRecordIfCurrentMonth(recordToSend, isNowInCurrentMonth);
    } else {
      addRecordIfCurrentMonth(recordToSend, isNowInCurrentMonth);
    }

    handleReset();
  } catch (error) {
    console.error(error);
  }
};
```

### 리팩토링을 결심한 이유

처음에는 단순히 액션을 리듀서로 정리하려는 목적이었지만, 구현하면서 submit 핸들러에 너무 많은 책임이 집중돼 있다는 점이 눈에 띄었습니다.  
사용자 인터랙션을 처리해야 하는 핸들러가 비즈니스 로직까지 떠안으면서 구조가 무거워졌습니다.

핵심 포인트는 가독성과 책임 분리.  
읽기 쉬운 구조, 각자 할 일을 명확히 나누는 것이 이번 리팩토링의 핵심이었습니다.

### 주요 문제점

- `handleSubmit`이 유효성 검사, 레코드 생성, 월 판단, 액션 분기까지 모두 처리
- `isSameYearMonth` 같은 판단 로직이 중복될 가능성 있음
- 상태 변환이 컴포넌트 내부에 있어 테스트성과 재사용성이 떨어짐

---

### 고려했던 방식들

`handleSubmit` 함수의 가독성과 책임 분리를 개선하기 위해, 다음과 같은 여러 구조를 검토했습니다.

### 1. “현재 월” 분기 로직을 핸들러에서 제거하고 리듀서에 위임하기

현재 구조에서는 `handleSubmit` 함수가 다음과 같은 많은 책임을 가지고 있습니다:
1. 레코드 생성
2. 생성/수정 분기
3. “현재 월” 판단

이 책임 중 일부를 리듀서로 넘길 수 있습니다. 예를 들어, 핸들러는 단일 액션(UPSERT_RECORD)만 디스패치하고, 리듀서가 내부에서 레코드가 현재 월에 속하는지 여부를 판단해 추가/수정/삭제 여부를 결정하도록 할 수 있습니다.

```js
// 컴포넌트 내부
recordDataDispatch({ type: 'UPSERT_RECORD', payload: record });

// 리듀서 내부
if (inCurrentMonth) {
  return exists ? 수정 : 추가;
} else if (exists) {
  return 삭제;
}
```

장점
- 핸들러는 유효성 검사 → 레코드 생성 → 디스패치 → 리셋만 담당하게 되어 단순해집니다.
- 비즈니스 로직은 리듀서에 집중되어 테스트와 관리가 쉬워집니다.

---

### 2. 모든 레코드를 저장하고, 화면에서 필터링하기

레코드를 월별로 삭제하거나 관리하지 않고, 모든 레코드를 상태에 저장한 채 렌더링 시점에서만 필터링하는 방식입니다.

```js
const visibleRecords = allRecords.filter(record =>
  isSameYearMonth(currentYear, currentMonth, record.date)
);
```

장점
- 월 관련 분기 로직 자체가 사라집니다.
- 전체 기록을 보관하므로, “지난 달 보기”나 “연도별 통계” 기능에도 쉽게 확장할 수 있습니다.
- `handleSubmit`은 API 호출과 디스패치만 처리하면 되어 더 간단해집니다.

---

### 3. 부수 효과(사이드 이펙트)를 커스텀 훅이나 서비스로 분리하기

ID 생성, 타임스탬프 처리, API 호출, 디스패치 등의 작업을 하나의 훅이나 서비스로 캡슐화할 수 있습니다. 이렇게 하면 컴포넌트는 “검증 후 저장”만 담당하면 됩니다.

```js
const saveRecord = useSaveRecord();
await saveRecord(formData, isEditMode);
```

장점
- 비즈니스 로직이 분리되어 관심사 분리가 잘 이루어집니다.
- 테스트 코드 작성이나 다른 화면에서의 재사용도 용이합니다.

---

### 4. 분기를 합친 단일 “upsert” 헬퍼 함수 사용

기존에 작성한 `addRecordIfCurrentMonth`, `updateRecordIfCurrentMonth` 같은 함수들을 하나로 통합해 `upsertIfCurrentMonth`처럼 처리할 수 있습니다.

```js
const actionType = editMode
  ? inMonth ? 'UPDATE_RECORD' : 'DELETE_RECORD'
  : inMonth ? 'ADD_RECORD' : null;
```

장점
- 중복된 헬퍼 함수를 하나로 통합해 코드가 간결해집니다.
- 월 분기를 유지하면서도, 복잡한 로직을 한 곳에서 관리할 수 있습니다.

---

### 최종 구조

#### 주요 선택 사항

- 액션 타입을 `ADD_RECORD`, `UPDATE_RECORD`, `DELETE_RECORD`, `SET_RECORDS`로 분리
- “현재 월인지” 판단은 핸들러에서 수행하고 결과만 리듀서로 전달
- 핸들러는 검증 → 생성 → dispatch → reset만 담당
- 리듀서는 순수 함수로 상태만 처리

### 개선된 handleSubmit

```js
const handleSubmit = () => {
  if (!recordSchema.safeParse(formData).success) return;

  const isEditMode = Boolean(originalFormData);
  const newRecord = buildRecordToSend(formData, isEditMode);
  const isInCurrentMonth = isSameYearMonth(currentYear, currentMonth, newRecord.date);

  dispatch({
    type: isEditMode ? 'UPDATE_RECORD' : 'ADD_RECORD',
    payload: { record: newRecord, isInCurrentMonth }
  });

  handleReset();
};
```

### 리듀서 동작 예시

- `ADD_RECORD`: 현재 월이면 추가
- `UPDATE_RECORD`: 현재 월이면 수정, 아니면 삭제
- `DELETE_RECORD`: 직접 삭제
- `SET_RECORDS`: 전체 초기화

### 리팩토링 효과

- 컴포넌트는 UI 처리에만 집중
- 리듀서는 상태 관리에 집중
- 코드 흐름이 간결하고 명확해짐
- 테스트, 유지보수, 협업이 쉬워짐

### 결론

- 액션은 명확히 분리하고,
- 월 비교는 핸들러에서 미리 판단해서 리듀서는 순수함을 유지
- `handleSubmit`은 본래 역할인 UI 처리에 집중할 수 있게 됨
- 구조가 깔끔해지며 유지보수성과 테스트 편의성이 크게 향상됨