### PR TITLE
♻️ refactor: split theme into raw tokens and semantic tokens within single file

### DIFF
--- a/src/app/theme/theme.js
+++ b/src/app/theme/theme.js
@@ -1,125 +1,137 @@
-const theme = {
-  fonts: {
-    serif: 'Chosunilbo_myungjo, serif',
-    semibold: 'Pretendard, sans-serif',
-    light: 'Pretendard, sans-serif',
-  },
-  fontSizes: {
-    large: '48px',
-    medium: '24px',
-    small: '16px',
-    xSmall: '14px',
-    xxSmall: '12px',
-  },
-  lineHeights: {
-    large: '56px',
-    medium: '32px',
-    small: '24px',
-    xSmall: '22px',
-    xxSmall: '16px',
-  },
-  colors: {
-    // Grayscale colors
-    grayscale50: '#FFFFFF',
-    grayscale100: '#FBFCFD',
-    grayscale200: '#F1F4F8',
-    grayscale300: '#777D84',
-    grayscale400: '#000000',
-
-    // Pastel colors
-    pastelAlmondFrost: '#A28B78',
-    pastelPorsche: '#E39D5D',
-    pastelChenin: '#D7CA6B',
-    pastelCaper: '#AACD7E',
-    pastelCruise: '#BCDFD3',
-    pastelOnahu: '#C5E0EB',
-    pastelGlacier: '#7DB7BF',
-    pastelSeagull: '#79B2CA',
-    pastelJordyBlue: '#73A4D0',
-    pastelPerano: '#A7B9E9',
-    pastelPerfume: '#BDA6E1',
-    pastelLavenderPink: '#F0B0D3',
-    pastelAmaranth: '#E93B5A',
-    pastelChestnut: '#C04646',
-
-    // Neutral colors
-    neutralSurfaceDefault: '#FFFFFF',
-    neutralSurfaceWeak: '#FBFCFD',
-    neutralSurfacePoint: '#F1F4F8',
-    neutralTextDefault: '#000000',
-    neutralTextWeak: '#777D84',
-    neutralTextRevDefault: '#FFFFFF',
-    neutralBorderDefault: '#000000',
-
-    // Brand colors
-    brandSurfaceDefault: '#FFFFFF',
-    brandTextIncome: '#79B2CA',
-    brandTextExpense: '#E93B5A',
-
-    //danger colors
-    dangerSurfaceDefault: '#E93B5A',
-    dangerTextDefault: '#E93B5A',
-    dangerTextRevDefault: '#FFFFFF',
-    dangerBorderDefault: '#E93B5A',
-  },
+// 1. Design tokens (raw values)
+const fonts = {
+  serif: 'Chosunilbo_myungjo, serif',
+  semibold: 'Pretendard, sans-serif',
+  light: 'Pretendard, sans-serif',
 };
 
-// Add typography here
-theme.typography = {
+const fontSizes = {
+  large: '48px',
+  medium: '24px',
+  small: '16px',
+  xSmall: '14px',
+  xxSmall: '12px',
+};
+
+const lineHeights = {
+  large: '56px',
+  medium: '32px',
+  small: '24px',
+  xSmall: '22px',
+  xxSmall: '16px',
+};
+
+const colorsRaw = {
+  // Grayscale
+  grayscale50: '#FFFFFF',
+  grayscale100: '#FBFCFD',
+  grayscale200: '#F1F4F8',
+  grayscale300: '#777D84',
+  grayscale400: '#000000',
+
+  // Pastel
+  pastelAlmondFrost: '#A28B78',
+  pastelPorsche: '#E39D5D',
+  pastelChenin: '#D7CA6B',
+  pastelCaper: '#AACD7E',
+  pastelCruise: '#BCDFD3',
+  pastelOnahu: '#C5E0EB',
+  pastelGlacier: '#7DB7BF',
+  pastelSeagull: '#79B2CA',
+  pastelJordyBlue: '#73A4D0',
+  pastelPerano: '#A7B9E9',
+  pastelPerfume: '#BDA6E1',
+  pastelLavenderPink: '#F0B0D3',
+  pastelAmaranth: '#E93B5A',
+  pastelChestnut: '#C04646',
+};
+
+// 2. Semantic tokens (meaningful groupings)
+const typography = {
   serif48: {
-    fontFamily: theme.fonts.serif,
-    fontSize: theme.fontSizes.large,
-    lineHeight: theme.lineHeights.large,
+    fontFamily: fonts.serif,
+    fontSize: fontSizes.large,
+    lineHeight: lineHeights.large,
   },
   serif24: {
-    fontFamily: theme.fonts.serif,
-    fontSize: theme.fontSizes.medium,
-    lineHeight: theme.lineHeights.medium,
+    fontFamily: fonts.serif,
+    fontSize: fontSizes.medium,
+    lineHeight: lineHeights.medium,
   },
   serif14: {
-    fontFamily: theme.fonts.serif,
-    fontSize: theme.fontSizes.xSmall,
-    lineHeight: theme.lineHeights.xxSmall,
+    fontFamily: fonts.serif,
+    fontSize: fontSizes.xSmall,
+    lineHeight: lineHeights.xxSmall,
   },
   semibold16: {
-    fontFamily: theme.fonts.semibold,
-    fontSize: theme.fontSizes.small,
-    lineHeight: theme.lineHeights.small,
+    fontFamily: fonts.semibold,
+    fontSize: fontSizes.small,
+    lineHeight: lineHeights.small,
     fontWeight: '600',
   },
   semibold14: {
-    fontFamily: theme.fonts.semibold,
-    fontSize: theme.fontSizes.xSmall,
-    lineHeight: theme.lineHeights.xxSmall,
+    fontFamily: fonts.semibold,
+    fontSize: fontSizes.xSmall,
+    lineHeight: lineHeights.xxSmall,
     fontWeight: '600',
   },
   semibold12: {
-    fontFamily: theme.fonts.semibold,
-    fontSize: theme.fontSizes.xxSmall,
-    lineHeight: theme.lineHeights.xxSmall,
+    fontFamily: fonts.semibold,
+    fontSize: fontSizes.xxSmall,
+    lineHeight: lineHeights.xxSmall,
     fontWeight: '600',
   },
   light16: {
-    fontFamily: theme.fonts.light,
-    fontSize: theme.fontSizes.small,
-    lineHeight: theme.lineHeights.medium,
+    fontFamily: fonts.light,
+    fontSize: fontSizes.small,
+    lineHeight: lineHeights.medium,
     fontWeight: '300',
   },
   light14: {
-    fontFamily: theme.fonts.light,
-    fontSize: theme.fontSizes.xSmall,
-    lineHeight: theme.lineHeights.small,
+    fontFamily: fonts.light,
+    fontSize: fontSizes.xSmall,
+    lineHeight: lineHeights.small,
     fontWeight: '300',
   },
   light12: {
-    fontFamily: theme.fonts.light,
-    fontSize: theme.fontSizes.xxSmall,
-    lineHeight: theme.lineHeights.small,
+    fontFamily: fonts.light,
+    fontSize: fontSizes.xxSmall,
+    lineHeight: lineHeights.small,
     fontWeight: '300',
   },
 };
 
-theme.categoryColors = {
+const neutral = {
+  neutralSurfaceDefault: colorsRaw.grayscale50,
+  neutralSurfaceWeak: colorsRaw.grayscale100,
+  neutralSurfacePoint: colorsRaw.grayscale200,
+  neutralTextDefault: colorsRaw.grayscale400,
+  neutralTextWeak: colorsRaw.grayscale300,
+  neutralTextRevDefault: colorsRaw.grayscale50,
+  neutralBorderDefault: colorsRaw.grayscale400,
+};
+
+const brand = {
+  brandSurfaceDefault: colorsRaw.grayscale50,
+  brandTextIncome: colorsRaw.pastelSeagull,
+  brandTextExpense: colorsRaw.pastelAmaranth,
+};
+
+const danger = {
+  dangerSurfaceDefault: colorsRaw.pastelAmaranth,
+  dangerTextDefault: colorsRaw.pastelAmaranth,
+  dangerTextRevDefault: colorsRaw.grayscale50,
+  dangerBorderDefault: colorsRaw.pastelAmaranth,
+};
+
+const colors = {
+  ...colorsRaw,
+  ...neutral,
+  ...brand,
+  ...danger,
+};
+
+const categoryColors = {
   생활: 'pastelPerano',
   쇼핑뷰티: 'pastelChenin',
   '의료/건강': 'pastelCruise',
@@ -130,6 +142,12 @@ theme.categoryColors = {
   월급: 'pastelPorsche',
   '기타 수입': 'pastelAlmondFrost',
   용돈: 'pastelCaper',
+};
+
+const theme = {
+  typography,
+  colors,
+  categoryColors,
 };
 
 export default theme;

--- a/src/app/theme/theme.js
+++ b/src/app/theme/theme.js
@@ -44,16 +44,17 @@ const theme = {
 
     // Neutral colors
     neutralSurfaceDefault: '#FFFFFF',
-    neutralSurfaceWeak: '##FBFCFD',
+    neutralSurfaceWeak: '#FBFCFD',
+    neutralSurfacePoint: '#F1F4F8',
     neutralTextDefault: '#000000',
-    neutralTextWeak: '##777D84',
+    neutralTextWeak: '#777D84',
     neutralTextRevDefault: '#FFFFFF',
     neutralBorderDefault: '#000000',
 
     // Brand colors
     brandSurfaceDefault: '#FFFFFF',
     brandTextIncome: '#79B2CA',
-    brandTextExpense: '##E93B5A',
+    brandTextExpense: '#E93B5A',
 
     //danger colors
     dangerSurfaceDefault: '#E93B5A',

--- a/src/app/theme/theme.js
+++ b/src/app/theme/theme.js
@@ -119,4 +119,17 @@ theme.typography = {
   },
 };
 
+theme.categoryColors = {
+  생활: 'pastelPerano',
+  쇼핑뷰티: 'pastelChenin',
+  '의료/건강': 'pastelCruise',
+  식비: 'pastelOnahu',
+  교통: 'pastelGlacier',
+  '문화/여가': 'pastelPerfume',
+  미분류: 'pastelLavenderPink',
+  월급: 'pastelPorsche',
+  '기타 수입': 'pastelAlmondFrost',
+  용돈: 'pastelCaper',
+};
+
 export default theme;


### PR DESCRIPTION
## 완료 작업 목록

### 💄스타일 수정
- theme.js에 잘못된 색상값 수정

### ♻️ 리팩토링
- theme.js 하나의 파일에서 design tokens(raw)와 semantic tokens 분리  
- fonts, fontSizes, lineHeights, colorsRaw 정의  
- typography, neutral/brand/danger color 그룹 및 categoryColors 구성  

## 주요 고민과 해결과정
- **확장성·가독성 부족**: 기존 theme에 raw 값과 의미 값이 혼합  
- **책임 분리**: design/semantic 토큰을 나눠 유지보수성·재사용성 향상  
