### PR TITLE
✨ Feat: form reset

### DIFF
--- a/src/features/form/components/ButtonContainer.jsx
+++ b/src/features/form/components/ButtonContainer.jsx
@@ -1,0 +1,3 @@
+export default function ButtonContainer() {
+  return <div>ButtonContainer</div>;
+}

--- a/src/features/form/components/Form.jsx
+++ b/src/features/form/components/Form.jsx
@@ -5,11 +5,13 @@ import DescriptionInput from './DescriptionInput';
 import PaymentMethodSelect from './PaymentMethodSelect';
 import CategorySelect from './CategorySelect';
 import ConfirmButton from './ConfirmButton';
+import ResetFormButton from './ResetFormButton';
 
 function Form({
   formData,
   onChange,
   onSubmit,
+  onReset,
   paymentOptions,
   categoryOptions,
   isFormValid,
@@ -58,6 +60,7 @@ function Form({
       />
 
       <ConfirmButton onClick={onSubmit} isFormValid={isFormValid} />
+      <ResetFormButton onClick={onReset} />
     </form>
   );
 }

--- a/src/features/form/components/ResetFormButton.jsx
+++ b/src/features/form/components/ResetFormButton.jsx
@@ -1,0 +1,20 @@
+// CancelButton.jsx
+import styled from '@emotion/styled';
+
+const StyledResetFormButton = styled.button`
+  ${({ theme }) => theme.typography.semibold14};
+  color: ${({ theme }) => theme.colors.dangerTextDefault};
+  cursor: pointer;
+`;
+
+export default function ResetFormButton({
+  isEditMode,
+  onClick,
+  children = '↺',
+}) {
+  return (
+    <StyledResetFormButton isEditMode={isEditMode} onClick={onClick}>
+      {children}
+    </StyledResetFormButton>
+  );
+}

--- a/src/features/form/index.jsx
+++ b/src/features/form/index.jsx
@@ -4,7 +4,7 @@ import Form from './components/Form';
 
 const TEST_USER_ID = 1;
 
-function FormContainer({ formData, onChange, onSubmit, isFormValid }) {
+function FormContainer({ formData, onChange, onSubmit, onReset, isFormValid }) {
   const { payments, loading, error } = useFetchPayments(TEST_USER_ID);
 
   if (loading) return <div>결제수단을 불러오는 중입니다...</div>;
@@ -15,6 +15,7 @@ function FormContainer({ formData, onChange, onSubmit, isFormValid }) {
       formData={formData}
       onChange={onChange}
       onSubmit={onSubmit}
+      onReset={onReset}
       paymentOptions={payments}
       categoryOptions={CATEGORY_TYPES[formData.type]}
       isFormValid={isFormValid}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -91,6 +91,7 @@ function HomePage() {
         formData={formData}
         onChange={handleChange}
         onSubmit={handleSubmit}
+        onReset={handleReset}
         isFormValid={isSubmitEnabled}
       />
       <Record


### PR DESCRIPTION
## 작업 완료 내역

### ✨ 기능 추가
- **입력 폼 초기화 버튼 구현**  
  - 사용자가 생성·수정 모드 구분 없이 언제든 폼을 초기 상태로 되돌릴 수 있는 초기화 버튼을 추가했습니다.  
  - 버튼에는 직관적인 이모지 아이콘을 사용하고, 붉은색으로 강조하여 주요 동작임을 시각적으로 표현했습니다.

## 주요 고민 및 해결과정

### 1. **입력폼 초기화 UX 설계**

#### 🧐 고민의 배경
- 기존 입력폼에 초기화 기능이 없어 사용자가 의도한 시점에 쉽게 폼을 초기 상태로 돌릴 수 없었습니다.  
- 생성(신규 작성)과 수정(편집) 상황을 모두 고려하며, 별도의 ‘취소’ 버튼을 두는 것은 오히려 복잡도를 높일 수 있었습니다.

#### 고려한 방식
1. **수정 취소 버튼 생성**  
   - 장점: 수정 모드에서 직관적으로 ‘취소’ 동작을 인지할 수 있음  
   - 단점: 생성 모드에도 별도 ‘취소’ 명칭이 필요해 버튼 이름과 동작을 분기해야 함  

2. **폼 외부 클릭 시 초기화**  
   - 장점: 클릭 한 번으로 빠른 초기화 가능  
   - 단점: 실수로 영역 밖을 클릭하면 수정 중인 데이터가 의도치 않게 모두 삭제될 위험  

3. **초기화 버튼 생성**  
   - 장점: 생성·수정 모드 구분 없이 단일 액션으로 폼 리셋 가능  
   - 단점: UI에 초기화 버튼을 별도로 배치해야 함  

#### ✅ 최종 해결
- **초기화 버튼 생성 채택**  
  - 버튼 클릭만으로 폼을 초기화하도록 구현하여 오작동 위험 차단  
  - 문자열 대신 이모지 아이콘(🔄)을 사용해 직관성을 높임  
  - 붉은색 강조로 주요 동작임을 명확히 표현  
  - 초기화 시 기존에 선택된 내역도 함께 해제되도록 로직을 추가하여 상태 일관성 확보  
