### PR TITLE
🐛 fix: prevent form and record flicker on param change, improve error handling

### DIFF
--- a/src/app/Content.jsx
+++ b/src/app/Content.jsx
@@ -14,18 +14,14 @@ export default function Content() {
   const { records, dispatch } = useRecordState(fetchedData);
 
   useEffect(() => {
-    if (!loading && fetchedData) {
+    if (!loading) {
       dispatch({ type: 'SET_RECORDS', payload: fetchedData });
     }
-  }, [loading, fetchedData]);
+  }, [loading, fetchedData, dispatch]);
 
   return (
     <ContentWrapper>
-      {loading ? (
-        <div>loading...</div>
-      ) : (
-        <Outlet context={{ records, dispatch }} />
-      )}
+      <Outlet context={{ records, dispatch, loading }} />
     </ContentWrapper>
   );
 }

--- a/src/app/Content.jsx
+++ b/src/app/Content.jsx
@@ -10,7 +10,12 @@ const ContentWrapper = styled.main`
 
 export default function Content() {
   const { year, month } = useParams();
-  const { data: fetchedData, loading } = useFetchRecordsByDate(year, month);
+  const {
+    data: fetchedData,
+    loading,
+    error,
+    refetch,
+  } = useFetchRecordsByDate(year, month);
   const { records, dispatch } = useRecordState(fetchedData);
 
   useEffect(() => {
@@ -21,7 +26,7 @@ export default function Content() {
 
   return (
     <ContentWrapper>
-      <Outlet context={{ records, dispatch, loading }} />
+      <Outlet context={{ records, dispatch, loading, error, refetch }} />
     </ContentWrapper>
   );
 }

--- a/src/features/record/components/EmptyMessage.jsx
+++ b/src/features/record/components/EmptyMessage.jsx
@@ -1,0 +1,18 @@
+import Message from '../../../shared/components/Message';
+
+const StyledMessage = styled(Message)`
+  text-align: center;
+
+  ${({ theme }) => theme.typography.medium16};
+  color: ${({ theme }) => theme.colors.dangerTextDefault};
+`;
+
+export default function EmptyMessage() {
+  return (
+    <StyledMessage>
+      기록한 내역이 없어요! <br />
+      가계부를 작성해주세요! <br />
+      📘
+    </StyledMessage>
+  );
+}

--- a/src/features/record/components/ErrorMessage.jsx
+++ b/src/features/record/components/ErrorMessage.jsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import Message from '../../../shared/components/Message';
+
+const ErrorContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+
+  background: ${({ theme }) => theme.colors.dangerSurfaceSubtle};
+  padding: 24px;
+`;
+
+const StyledMessage = styled(Message)`
+  text-align: center;
+
+  ${({ theme }) => theme.typography.medium16};
+  color: ${({ theme }) => theme.colors.dangerTextDefault};
+`;
+
+const RetryButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 1px solid ${({ theme }) => theme.colors.dangerSurfaceDefault};
+  color: ${({ theme }) => theme.colors.dangerSurfaceDefault};
+`;
+
+export default function ErrorMessage({ onRetry }) {
+  return (
+    <ErrorContainer>
+      <StyledMessage>
+        내역을 가져오는데 에러가 발생했습니다.
+        <br />
+        다시 시도해주세요 😢
+      </StyledMessage>
+      <RetryButton onClick={onRetry}>↺</RetryButton>
+    </ErrorContainer>
+  );
+}

--- a/src/features/record/index.jsx
+++ b/src/features/record/index.jsx
@@ -1,11 +1,16 @@
 import React, { useState, useMemo } from 'react';
+import { useOutletContext } from 'react-router-dom';
 import styled from '@emotion/styled';
-
 import { groupByDate, filterGroupedByType } from './utils/utils';
+import ErrorMessage from './components/ErrorMessage';
+import EmptyMessage from './components/EmptyMessage';
 import RecordListHeader from './components/RecordListHeader';
 import RecordDateGroup from './components/RecordDateGroup';
 
 const RecordListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
   width: 100%;
   max-width: 800px;
   margin: 0 auto;
@@ -21,6 +26,7 @@ export default function RecordList({
   onDelete,
   editingId,
 }) {
+  const { error, fetchRecords } = useOutletContext();
   const [showIncome, setShowIncome] = useState(true);
   const [showExpense, setShowExpense] = useState(true);
 
@@ -33,6 +39,11 @@ export default function RecordList({
     [groupedByDate, showIncome, showExpense]
   );
 
+  const recordList = Object.entries(visibleGroups);
+
+  if (error) return <ErrorMessage onRetry={fetchRecords} />;
+  if (recordData.length === 0) return <EmptyMessage />;
+
   return (
     <RecordListContainer>
       <RecordListHeader
@@ -42,9 +53,8 @@ export default function RecordList({
         onToggleIncome={() => setShowIncome((prev) => !prev)}
         onToggleExpense={() => setShowExpense((prev) => !prev)}
       />
-
       <ListBox>
-        {Object.entries(visibleGroups).map(([date, items]) => (
+        {recordList.map(([date, items]) => (
           <RecordDateGroup
             key={date}
             date={date}

--- a/src/shared/components/Message.jsx
+++ b/src/shared/components/Message.jsx
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  color: ${({ theme }) => theme.colors.neutralTextWeak};
+  background-color: ${({ theme }) => theme.colors.neutralSurface};
+`;
+
+export default function Message({ children }) {
+  return <Wrapper>{children}</Wrapper>;
+}

--- a/src/shared/hooks/useFetchRecordsByDate.js
+++ b/src/shared/hooks/useFetchRecordsByDate.js
@@ -30,7 +30,13 @@ const useFetchRecordsByDate = (year, month) => {
     }
   }, [year, month]);
 
-  return { data, loading, error };
+  const refetch = () => {
+    setLoading(true);
+    setError(null);
+    fetchData(year, month);
+  };
+
+  return { data, loading, error, refetch };
 };
 
 export default useFetchRecordsByDate;

--- a/src/shared/hooks/useFetchRecordsByDate.js
+++ b/src/shared/hooks/useFetchRecordsByDate.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
 const useFetchRecordsByDate = (year, month) => {
-  const [data, setData] = useState(null);
+  const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -25,6 +25,7 @@ const useFetchRecordsByDate = (year, month) => {
     if (year && month) {
       setLoading(true);
       setError(null);
+      setData([]);
       fetchData(year, month);
     }
   }, [year, month]);


### PR DESCRIPTION
## 작업 완료 내역

### 🐛 버그 수정
- **파라미터 변경 시 폼과 레코드 깜빡임 문제 해결**  
  - `loading` 조건을 Outlet 내부로 이동하여 불필요한 remount 루프 방지
  - `year/month` 파라미터 변경 시 records를 빈 배열로 리셋
  - fetch 실패 시 이전 records를 초기화하여 stale 데이터 제거

### ✨ 기능 추가
- **useFetchRecordsByDate 훅 개선**
  - `refetch` 함수 구현 및 반환값에 `error`, `refetch` 포함
  - Outlet Context를 통해 `error`와 `refetch` 전달하도록 상위 컴포넌트 업데이트

- **에러 및 빈 상태 메시지 컴포넌트 추가**
  - 공통 Message 컴포넌트 생성
  - fetch 실패 시 에러 메시지 노출
  - 해당 월에 내역이 없을 경우 빈 메시지 노출

---

## 주요 고민 및 해결과정

### 1. **파라미터 변경 시 깜빡임과 상태 불일치 문제**

#### [=> 문제 해결 wiki 링크](https://github.com/wan0514/fe-bye2money/wiki/%5B%EB%AC%B8%EC%A0%9C%EC%99%80-%ED%95%B4%EA%B2%B0%5D-%EB%82%A0%EC%A7%9C-%EB%B3%80%EA%B2%BD-%EC%8B%9C-Outlet-%EA%B9%9C%EB%B9%A1%EC%9E%84%EA%B3%BC-%EC%83%81%ED%83%9C-%EB%B6%88%EC%9D%BC%EC%B9%98-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)

#### 🧐 고민의 배경
- 기존에는 `loading` 상태를 부모 컴포넌트에서 직접 조건부로 처리했는데, 이로 인해 `Outlet`이 `loading` 상태에 따라 mount/unmount를 반복하는 문제가 있었습니다.
- 또한 `year/month`가 변경될 때 새로운 fetch가 실패하면 이전 records 상태가 유지되어 사용자가 잘못된 내역을 보게 되는 문제가 있었습니다.

#### ✅ 최종 해결
- `loading` 조건을 Outlet 내부로 옮겨, mount/unmount 루프 없이 자연스럽게 상태 변화만 반영되도록 개선했습니다.
- `year/month`가 변경되면 records를 빈 배열로 먼저 초기화하고, 이후 fetch 결과로 갱신하도록 변경했습니다.
- fetch 실패 시에도 기존 records를 그대로 두는 것이 아니라 초기화하여 **오래된 데이터(stale data)가 남지 않게** 처리했습니다.

---
