### PR TITLE
Feature/crud api integration

### DIFF
--- a/src/shared/api/paymentsApi.js
+++ b/src/shared/api/paymentsApi.js
@@ -1,0 +1,38 @@
+import { BASE_URL, API } from '../constants/api';
+
+// 결제수단 전체 가져오기 (GET)
+export async function getPayments() {
+  const response = await fetch(`${BASE_URL}${API.PAYMENTS}`);
+
+  if (!response.ok) {
+    throw new Error('결제수단 불러오기 실패');
+  }
+
+  return await response.json();
+}
+
+// 결제수단 수정하기 (PATCH)
+export async function patchPayment(payment) {
+  const response = await fetch(`${BASE_URL}${API.PAYMENTS}/${payment.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payment),
+  });
+
+  if (!response.ok) {
+    throw new Error('결제수단 수정 실패');
+  }
+
+  return await response.json();
+}
+
+// 결제수단 삭제하기 (DELETE)
+export async function deletePayment(id) {
+  const response = await fetch(`${BASE_URL}${API.PAYMENTS}/${id}`, {
+    method: 'DELETE',
+  });
+
+  if (!response.ok) {
+    throw new Error('결제수단 삭제 실패');
+  }
+}

--- a/src/shared/api/recordsApi.js
+++ b/src/shared/api/recordsApi.js
@@ -1,0 +1,58 @@
+import { BASE_URL, API } from '../constants/api';
+
+// 레코드 가져오기
+export async function getRecords({ year, month }) {
+  const response = await fetch(
+    `${BASE_URL}${API.RECORDS}?year=${year}&month=${month}`
+  );
+
+  if (!response.ok) {
+    throw new Error('레코드 불러오기 실패');
+  }
+
+  const data = await response.json();
+  return data;
+}
+
+// 레코드 생성
+export async function postRecordToServer(record) {
+  const response = await fetch(`${BASE_URL}${API.RECORDS}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(record),
+  });
+
+  if (!response.ok) {
+    throw new Error('레코드 생성 실패');
+  }
+
+  const data = await response.json();
+  return data;
+}
+
+// 레코드 수정
+export async function patchRecordToServer(record) {
+  const response = await fetch(`${BASE_URL}${API.RECORDS}/${record.id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(record),
+  });
+
+  if (!response.ok) {
+    throw new Error('레코드 수정 실패');
+  }
+
+  const data = await response.json();
+  return data;
+}
+
+// 레코드 삭제
+export async function deleteRecordFromServer(id) {
+  const response = await fetch(`${BASE_URL}${API.RECORDS}/${id}`, {
+    method: 'DELETE',
+  });
+
+  if (!response.ok) {
+    throw new Error('레코드 삭제 실패');
+  }
+}

--- a/src/shared/hooks/useFetchPayments.js
+++ b/src/shared/hooks/useFetchPayments.js
@@ -1,33 +1,31 @@
-import { useState, useEffect } from 'react';
-import { BASE_URL, API } from '../constants/api';
+import { useState, useEffect, useCallback } from 'react';
+import { getPayments } from '../api/paymentsApi';
 
 export default function useFetchPayments(userId) {
   const [payments, setPayments] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const fetchPayments = async () => {
-    try {
-      const response = await fetch(`${BASE_URL}${API.PAYMENTS}`);
-      if (!response.ok) {
-        throw new Error('Data file not found');
-      }
+  const fetchPayments = useCallback(async () => {
+    if (!userId) return;
 
-      const result = await response.json();
+    setLoading(true);
+    setError(null);
+    setPayments([]);
+
+    try {
+      const result = await getPayments();
       setPayments(result);
     } catch (err) {
-      setError(err.message);
+      setError(err.message || '결제수단을 불러오는 데 실패했습니다.');
     } finally {
       setLoading(false);
     }
-  };
-
-  useEffect(() => {
-    if (!userId) return;
-    setLoading(true);
-    setError(null);
-    fetchPayments();
   }, [userId]);
 
-  return { payments, loading, error };
+  useEffect(() => {
+    fetchPayments();
+  }, [fetchPayments]);
+
+  return { payments, loading, error, refetch: fetchPayments };
 }

--- a/src/shared/hooks/useFetchRecordsByDate.js
+++ b/src/shared/hooks/useFetchRecordsByDate.js
@@ -1,44 +1,33 @@
-import { useState, useEffect } from 'react';
-import { BASE_URL, API } from '../constants/api';
+import { useState, useEffect, useCallback } from 'react';
+import { getRecords } from '../api/recordsApi';
 
 const useFetchRecordsByDate = (year, month) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const fetchData = async (year, month) => {
+  const fetchData = useCallback(async () => {
+    if (!year || !month) return;
+
+    setLoading(true);
+    setError(null);
+    setData([]);
+
     try {
-      const response = await fetch(
-        `${BASE_URL}${API.RECORDS}?year=${year}&month=${month}`
-      );
-      if (!response.ok) {
-        throw new Error('Data file not found');
-      }
-      const result = await response.json();
+      const result = await getRecords({ year, month });
       setData(result);
     } catch (err) {
-      setError(err.message); //TODO 메세지에 따라 외부에서 사용자를 위한 에러핸들링 처리
+      setError(err.message || '데이터를 불러오는데 실패했습니다.');
     } finally {
       setLoading(false);
     }
-  };
-
-  useEffect(() => {
-    if (year && month) {
-      setLoading(true);
-      setError(null);
-      setData([]);
-      fetchData(year, month);
-    }
   }, [year, month]);
 
-  const refetch = () => {
-    setLoading(true);
-    setError(null);
-    fetchData(year, month);
-  };
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
-  return { data, loading, error, refetch };
+  return { data, loading, error, refetch: fetchData };
 };
 
 export default useFetchRecordsByDate;


### PR DESCRIPTION
## 작업 완료 내역

### ✨ 기능 추가
- **CRUD 기능 json-server 연동**
  - Get, Create, Update, Delete 기능을 json-server API와 연결

### ♻️ 리팩토링
- **fetch 커스텀 훅 개선 및 API 함수 호출로 변경**
  - 각 커스텀 훅에서 직접 fetch 요청하는 대신 api 함수 호출로 변경
  - 내부 fetch 함수들(fetchData 등)을 `useCallback`으로 최적화
  - `loading`, `error` 상태 관리를 일관성 있게 정리
  - 데이터 로딩, 에러 핸들링, 데이터 상태 관리의 관심사를 명확히 분리

---

## 주요 고민 및 해결과정

### 1. **fetch 요청 로직을 어떻게 깔끔하게 분리할까?**

#### 🧐 **고민의 배경**

- CRUD 연동을 위해 각각의 커스텀 훅마다 fetch 로직을 작성하다 보니 **중복 코드**가 많아졌습니다.
- 특히, URL 하드코딩과 fetch 에러 처리, 로딩 상태 관리 등 공통 패턴이 반복되면서 **유지보수성 저하**가 우려되었습니다.
- 또한, 추후 GET 요청(fetch list 등)을 추가할 때도 중복을 피하고 싶었습니다.

#### **고려한 방식**

1. **각 커스텀 훅 내부에 fetch 로직을 개별 작성**  
   - 단기적으로는 빠르게 구현할 수 있지만, 훅 개수가 늘어날수록 코드가 복잡해지고 수정이 어려워질 것으로 판단했습니다.

2. **공통 fetch 함수를 api 폴더에 분리하고 훅에서는 호출만 하도록 설계**  
   - 중복을 줄이고, 공통 에러 처리/로딩 관리를 체계화할 수 있다고 판단했습니다.
   - API 함수의 책임과 훅의 책임을 분리하여 각각 가볍게 만들 수 있다고 생각했습니다.

#### ✅ **최종 해결**

- **api 폴더**를 새로 만들고, create/update/delete 관련 fetch 함수들을 이곳에 분리했습니다.
- 커스텀 훅에서는 이 api 함수들을 호출만 하도록 변경했습니다.
- 각 훅 내부에서는 `useCallback`으로 요청 함수를 감싸 최적화를 진행했고, `loading`, `error` 흐름을 명확하게 정리했습니다.
- **관심사를 명확히 분리한 덕분에** 이후에 GET 요청 추가나 에러 핸들링 수정이 훨씬 용이해졌습니다.
