### PR TITLE
🐛 fix: duplicated <main> tag rendering issue

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,12 +1,12 @@
 import Layout from '../layouts/Layout';
-import Content from './Content';
+import { Outlet } from 'react-router-dom';
 import Header from '../features/header';
 
 function App() {
   return (
     <Layout>
       <Header />
-      <Content />
+      <Outlet />
     </Layout>
   );
 }


### PR DESCRIPTION

## 완료 작업 목록
- 중첩되어 렌더링되던 `<main>` 컴포넌트 문제 해결

## 주요 고민과 해결 과정

### 문제 배경
React Developer Tools를 통해 컴포넌트 트리를 분석하던 중, `<main>` 태그가 중첩되어 렌더링되는 이슈를 발견했습니다.

<img width="347" alt="스크린샷: 이슈 발생 당시" src="https://github.com/user-attachments/assets/f50cca60-7fba-4d23-9dce-c6e7fcb880b3" />

### 원인 분석
- `App` 컴포넌트 내부에서 `Content`를 직접 렌더링하여 `<main>` 엘리먼트가 생성되고 있었고,
- 동시에 `Outlet`을 통해서도 `Content`가 렌더링되어 또 다른 `<main>`이 중첩되고 있었습니다.
- 결과적으로 `<main>` → `<main>` 구조가 발생해 비표준 DOM 트리가 만들어졌습니다.

### 문제 해결
- `App` 컴포넌트에서 `Content`를 직접 호출하지 않고, 대신 `<Outlet>`을 사용하도록 수정했습니다.
- 라우터(Route) 설정에서 `Content`를 삽입하는 구조는 유지하여 페이지 흐름은 변하지 않게 했습니다.
- 중복 생성되던 `<main>`을 제거하여 DOM 트리를 간결하고 명확하게 정리했습니다.

### 변경 후 결과
- `App`은 `Layout`, `Header`, `Outlet`만을 포함하여 역할이 명확해졌습니다.
- `Content`는 오직 라우터를 통해서만 렌더링됩니다.
- `<main>` 중첩 문제 해결 완료
- DOM 구조가 깨끗해지고, 컴포넌트 책임이 분리되어 유지보수성이 향상되었습니다.

<img width="394" alt="스크린샷: 수정 후" src="https://github.com/user-attachments/assets/0253fc47-b540-474b-8824-ba11349c536c" />