### PR TITLE
♻️ refactor : layout

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,13 +1,13 @@
-import Layout from '../layouts/Layout';
+import AppLayout from '../layouts/AppLayout';
 import { Outlet } from 'react-router-dom';
 import Header from '../features/header';
 
 function App() {
   return (
-    <Layout>
+    <AppLayout>
       <Header />
       <Outlet />
-    </Layout>
+    </AppLayout>
   );
 }
 

--- a/src/app/Content.jsx
+++ b/src/app/Content.jsx
@@ -1,12 +1,8 @@
-import styled from '@emotion/styled';
 import { useParams, Outlet } from 'react-router-dom';
 import { useEffect } from 'react';
 import useFetchRecordsByDate from '../shared/hooks/useFetchRecordsByDate';
 import useRecordState from '../shared/hooks/useRecordState';
-
-const ContentWrapper = styled.main`
-  flex: 1;
-`;
+import ContentLayout from '../layouts/ContentLayout';
 
 export default function Content() {
   const { year, month } = useParams();
@@ -25,8 +21,8 @@ export default function Content() {
   }, [loading, fetchedData, dispatch]);
 
   return (
-    <ContentWrapper>
+    <ContentLayout>
       <Outlet context={{ records, dispatch, loading, error, refetch }} />
-    </ContentWrapper>
+    </ContentLayout>
   );
 }

--- a/src/app/theme/globalStyle.js
+++ b/src/app/theme/globalStyle.js
@@ -14,24 +14,33 @@ const globalStyle = (theme) => css`
 
   ${resetStyles};
 
-  /* 버튼 커서 */
   button {
     cursor: pointer;
   }
 
-  /* 글로벌 커스텀 스타일 */
   body {
-    height: 100vh;
+    width: 100%;
+    height: 100%;
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    align-items: stretch;
+    justify-content: flex-start;
     font-family: 'Pretendard', sans-serif;
     background-color: ${theme.colors.grayscale50};
+
+    overflow: hidden;
 
     transition:
       background-color 0.2s ease,
       color 0.2s ease;
+  }
+
+  html,
+  body,
+  #root {
+    height: 100%;
+    margin: 0;
+    padding: 0;
   }
 `;
 

--- a/src/features/header/index.jsx
+++ b/src/features/header/index.jsx
@@ -14,7 +14,7 @@ import TabNavigation from './components/TabNavigation';
 
 const HeaderWrapper = styled.div`
   display: flex;
-  width: 100vw;
+  width: 100%;
   height: 216px;
   background-color: ${({ theme }) => theme.colors.pastelJordyBlue};
 `;

--- a/src/features/record/index.jsx
+++ b/src/features/record/index.jsx
@@ -9,15 +9,26 @@ import RecordDateGroup from './components/RecordDateGroup';
 
 const RecordListContainer = styled.div`
   display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   gap: 40px;
   width: 100%;
+  height: 100%;
   max-width: 800px;
-  margin: 0 auto;
 `;
 
 const ListBox = styled.div`
-  margin-top: 16px;
+  flex: 1 1 auto;
+  padding-right: 12px;
+  padding-bottom: 80px;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+
+  scrollbar-width: none; /* Firefox */
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera */
+  }
 `;
 
 export default function RecordList({

--- a/src/layouts/AppLayout.jsx
+++ b/src/layouts/AppLayout.jsx
@@ -1,14 +1,15 @@
 import styled from '@emotion/styled';
 
 const LayoutWrapper = styled.div`
-  width: 100vw;
-  height: 100vh;
+  position: relative;
+  width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-height: 100vh;
+  min-height: 100%;
 `;
 
-export default function Layout({ children }) {
+export default function AppLayout({ children }) {
   return <LayoutWrapper>{children}</LayoutWrapper>;
 }

--- a/src/layouts/BaseContent.jsx
+++ b/src/layouts/BaseContent.jsx
@@ -1,0 +1,14 @@
+import styled from '@emotion/styled';
+
+const BaseContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: -34px;
+`;
+
+export default BaseContent;

--- a/src/layouts/CalendarLayout.jsx
+++ b/src/layouts/CalendarLayout.jsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+import BaseContent from '../../shared/components/layout/BaseContent';
+
+const CalendarContent = styled(BaseContent)`
+  gap: 40px;
+`;
+
+export default function CalendarLayout({ children }) {
+  return <CalendarContent>{children}</CalendarContent>;
+}

--- a/src/layouts/ContentLayout.jsx
+++ b/src/layouts/ContentLayout.jsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+const ContentLayoutContainer = styled.main`
+  flex: 1;
+  position: relative;
+  width: 100%;
+`;
+
+export default function ContentLayout({ children }) {
+  return <ContentLayoutContainer>{children}</ContentLayoutContainer>;
+}

--- a/src/layouts/HomeLayout.jsx
+++ b/src/layouts/HomeLayout.jsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+import BaseContent from './BaseContent';
+
+const HomeContent = styled(BaseContent)`
+  gap: 34px;
+`;
+
+export default function HomeLayout({ children }) {
+  return <HomeContent>{children}</HomeContent>;
+}

--- a/src/layouts/StatsLayout.jsx
+++ b/src/layouts/StatsLayout.jsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+import BaseContent from '../../shared/components/layout/BaseContent';
+
+const StatsContent = styled(BaseContent)`
+  gap: 40px;
+`;
+
+export default function HomeLayout({ children }) {
+  return <StatsContent>{children}</StatsContent>;
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -12,6 +12,7 @@ import useRecordForm from '../features/form/hooks/useRecordForm';
 import initialFormState from '../features/form/reducers/initialFormState';
 import recordSchema from '../features/form/utils/recordSchema';
 
+import HomeLayout from '../layouts/HomeLayout';
 import Form from '../features/form';
 import Record from '../features/record';
 
@@ -70,7 +71,7 @@ function HomePage() {
   };
 
   return (
-    <>
+    <HomeLayout>
       <Form
         formData={formValues}
         onChange={onChange}
@@ -84,7 +85,7 @@ function HomePage() {
         onDelete={handleDelete}
         editingId={originalRecord?.id ?? null}
       />
-    </>
+    </HomeLayout>
   );
 }
 


### PR DESCRIPTION
## 작업 완료 내역

### ♻️ 리팩토링
- **레이아웃 구조 및 글로벌 스타일 개선**
  - `vh`, `vw` 단위를 제거하고 `100%` 기준으로 변경하여 스크롤 이슈 해결
  - 의미가 불명확했던 `Layout` 컴포넌트를 `AppLayout`으로 명확하게 명명
  - `Content` 레이아웃을 별도 컴포넌트로 분리하여 `Outlet`에 데이터 전달만 담당하도록 단순화

- **공통 레이아웃 컴포넌트 추출**
  - `Home`, `Stats`, `Calendar` 페이지에서 공통되는 레이아웃을 `PageLayout`으로 분리
  - 각 페이지 전용 레이아웃은 `PageLayout`을 확장하여 구성
  - 각 페이지 컴포넌트에서 해당 레이아웃을 불러와 적용함으로써 재사용성 및 유지보수성 개선

### 💄 스타일 개선
- **기록 리스트 영역 스크롤 처리**
  - 전체 페이지가 아닌, 리스트 영역만 스크롤되도록 레이아웃 수정

---

## 주요 고민 및 해결과정

### 1. **레이아웃 책임 분리와 명확화**

#### 🧐 문제의 배경
- 현재 레이아웃 구조는 다음과 같은 요구를 가지고 있음:
  1. 헤더와 메인을 포함하는 전체 레이아웃
  2. 메인 컴포넌트는 `relative`여야 하고, 내부 컴포넌트는 `absolute`로 배치됨
  3. 페이지마다 다른 요소 정렬 및 여백(`gap`) 필요

- 하지만 기존에는 레이아웃이 명확히 분리되어 있지 않아 혼란이 있었고,
  어떤 레이아웃이 어떤 역할을 맡고 있는지 구분이 어렵고 유지보수에도 불편함이 있었음

#### ✅ 정리한 구조
- **AppLayout**  
  헤더와 메인을 세로 정렬하는 가장 바깥쪽 레이아웃  
  → 앱 전역에서 사용하는 기본 레이아웃

- **ContentLayout**  
  메인을 감싸는 레이아웃  
  → 내부 컴포넌트가 `absolute`로 배치되기 위한 `relative` 부모 역할

- **PageLayout**  
  각 페이지 내부에서 요소(폼, 리스트 등)의 간격 및 정렬을 담당  
  → 페이지별 커스터마이징 용이

#### 💡 판단과 결정
- 기존에는 `Content` 안에서 요소들을 정렬하고 있었으나,
  페이지마다 정렬 기준과 간격이 달라지는 구조  
  (예: 홈 페이지는 gap 34px, 통계 페이지는 gap 40px)였기 때문에  
  공통 컴포넌트에서 고정 스타일을 두는 것은 부적절하다고 판단

- 따라서 내부 정렬은 각 페이지 전용 레이아웃에서 처리하도록 구조 분리하여  
  유지보수성과 확장성을 확보함