### PR TITLE
🐛 fix: handle browser auto-correction on invalid date input

### DIFF
--- a/src/features/form/components/DateInput.jsx
+++ b/src/features/form/components/DateInput.jsx
@@ -1,21 +1,6 @@
+import { formatDate } from '../utils/format';
+
 function DateInput({ value, onChange }) {
-  console.log(value);
-
-  function formatDate(value) {
-    if (!value) return '';
-    const numbersOnly = value.replace(/\D/g, '');
-
-    const year = numbersOnly.slice(0, 4);
-    const month = numbersOnly.slice(4, 6);
-    const day = numbersOnly.slice(6, 8);
-
-    let result = year;
-    if (month) result += '.' + month;
-    if (day) result += '.' + day;
-
-    return result;
-  }
-
   function handleChange(e) {
     const rawValue = e.target.value;
     const numbersOnly = rawValue.replace(/\D/g, '');

--- a/src/features/form/components/DateInput.jsx
+++ b/src/features/form/components/DateInput.jsx
@@ -1,11 +1,37 @@
 function DateInput({ value, onChange }) {
+  console.log(value);
+
+  function formatDate(value) {
+    if (!value) return '';
+    const numbersOnly = value.replace(/\D/g, '');
+
+    const year = numbersOnly.slice(0, 4);
+    const month = numbersOnly.slice(4, 6);
+    const day = numbersOnly.slice(6, 8);
+
+    let result = year;
+    if (month) result += '.' + month;
+    if (day) result += '.' + day;
+
+    return result;
+  }
+
+  function handleChange(e) {
+    const rawValue = e.target.value;
+    const numbersOnly = rawValue.replace(/\D/g, '');
+
+    const formatted = formatDate(numbersOnly);
+
+    onChange(formatted);
+  }
+
   return (
     <div>
       <label>일자</label>
       <input
-        type="date"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
+        placeholder="YYYY.MM.DD"
+        value={formatDate(value)}
+        onChange={handleChange}
       />
     </div>
   );

--- a/src/features/form/utils/format.js
+++ b/src/features/form/utils/format.js
@@ -1,0 +1,14 @@
+export function formatDate(value) {
+  if (!value) return '';
+  const numbersOnly = value.replace(/\D/g, '');
+
+  const year = numbersOnly.slice(0, 4);
+  const month = numbersOnly.slice(4, 6);
+  const day = numbersOnly.slice(6, 8);
+
+  let result = year;
+  if (month) result += '.' + month;
+  if (day) result += '.' + day;
+
+  return result;
+}

--- a/src/features/form/utils/recordSchema.js
+++ b/src/features/form/utils/recordSchema.js
@@ -16,12 +16,38 @@ const recordSchema = z
     category: z.string().min(1, '카테고리를 입력해주세요'),
   })
   .superRefine((data, ctx) => {
-    const validIds = CATEGORY_TYPES[data.type].map((c) => c.name); // 카테고리가 type에 맞는지 확인 : name(ex: '생활')으로 비교
+    const validIds = CATEGORY_TYPES[data.type].map((c) => c.name);
 
     if (!validIds.includes(data.category)) {
       ctx.addIssue({
         path: ['category'],
         message: `'${data.category}'는 ${data.type} 카테고리에 해당하지 않습니다`,
+        code: z.ZodIssueCode.custom,
+      });
+    }
+
+    // 🔥 추가: 날짜 유효성 체크
+    const datePattern = /^\d{4}\.\d{2}\.\d{2}$/;
+    if (!datePattern.test(data.date)) {
+      ctx.addIssue({
+        path: ['date'],
+        message: '날짜 형식이 올바르지 않습니다 (YYYY.MM.DD)',
+        code: z.ZodIssueCode.custom,
+      });
+      return;
+    }
+
+    const [year, month, day] = data.date.split('.').map(Number);
+    const date = new Date(year, month - 1, day);
+
+    if (
+      date.getFullYear() !== year ||
+      date.getMonth() !== month - 1 ||
+      date.getDate() !== day
+    ) {
+      ctx.addIssue({
+        path: ['date'],
+        message: '존재하지 않는 날짜입니다',
         code: z.ZodIssueCode.custom,
       });
     }

--- a/src/shared/utils/date.js
+++ b/src/shared/utils/date.js
@@ -7,7 +7,7 @@ export function getFormatDateToString(date) {
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
 
-  return `${year}-${month}-${day}`;
+  return `${year}.${month}.${day}`;
 }
 
 // example : "2025-04-22T13:00:00Z"


### PR DESCRIPTION

## 완료 작업 목록

### 🐛 버그 수정
- 날짜 입력 시 브라우저 자동 보정으로 인한 상태 미반영 문제 해결
- input type="date"에서 type="text"로 변경하여 브라우저의 자동 교정 기능 우회
- zod를 이용한 날짜 형식 유효성 검사 추가 (yyyy.mm.dd 포맷)
- 유효하지 않은 날짜 입력 시 버튼 비활성화 처리
- 내부 상태와 렌더링 포맷의 일관성을 위해 yyyy-mm-dd 포맷을 제거하고 yyyy.mm.dd 포맷으로 통일


## 주요 고민과 해결과정

### 날짜 입력 버그 원인 분석 및 해결

#### 문제의 배경

사용자가 날짜를 잘못 입력했을 때 (`input type="date"` 사용 시)  
브라우저가 해당 값을 자동으로 유효한 날짜로 **수정**하지만,  
이 변경 사항이 `onChange` 이벤트로 **감지되지 않는** 문제가 있었습니다.

예시:
- 사용자가 `2025-04-44`를 입력  
- 브라우저는 이를 `2025-05-14`로 자동 보정  
- 하지만 `onChange`는 이를 감지하지 않아 상태가 갱신되지 않음  
- 사용자 입장에서는 날짜가 정상처럼 보이지만, 폼 제출은 실패함

> 사용자는 문제를 인식하기 어렵고, 폼이 조용히 실패하는 UX 문제가 발생


#### 원인 분석

- `input type="date"`는 브라우저가 유효하지 않은 값을 자동으로 교정
- 교정된 값이 `onChange`로 감지되지 않음
- React 상태가 업데이트되지 않아 `zod` 유효성 검사에 실패
- 버튼은 비활성화되지 않고 제출 시에야 실패하게 됨


#### 해결 방법

#### 1. `type="text"`로 변경
- 브라우저의 자동 교정 기능 우회
- 입력값을 그대로 받아와 상태로 관리 가능

#### 2. `zod` 유효성 검사 추가
```ts
date: z
  .string()
  .regex(/^\d{4}\.\d{2}\.\d{2}$/, '날짜는 yyyy.mm.dd 형식이어야 합니다')
```

#### 3. 버튼 제출 조건 강화
- 유효하지 않으면 버튼 비활성화
- 사용자의 실수로 인한 조용한 실패 방지

#### 4. 날짜 포맷 일관화
- 렌더링 포맷과 동일한 `yyyy.mm.dd` 포맷으로 통일
- 기존의 `yyyy-mm-dd` 포맷 제거


#### 💡 향후 개선 방향

- 에러 메시지에 따른 안내 UI 추가 예정
- `zod.safeParse()` 실패 시 사용자에게 구체적인 오류 안내 메시지 제공



