### PR TITLE
🏗️ build: svgr config setting

### DIFF
--- a/src/features/header/components/TabNavigation.jsx
+++ b/src/features/header/components/TabNavigation.jsx
@@ -13,6 +13,7 @@ const IconButton = styled.div`
   padding: 8px;
   border-radius: 50%;
 
+  color: ${({ theme }) => theme.colors.neutralTextDefault};
   background-color: ${({ active }) => (active ? 'white' : 'transparent')};
   transition: background-color 0.3s ease;
 

--- a/svgr.config.js
+++ b/svgr.config.js
@@ -1,0 +1,22 @@
+export default {
+  icon: true,
+  expandProps: 'start',
+  svgProps: {
+    color: 'inherit', // 모든 SVG는 부모 color를 따르게
+  },
+  replaceAttrValues: {
+    '#000': 'currentColor',
+    '#000000': 'currentColor',
+    black: 'currentColor',
+  },
+  svgoConfig: {
+    plugins: [
+      {
+        name: 'removeAttrs',
+        params: {
+          attrs: '(stroke|fill)', // 기존 fill/stroke 제거
+        },
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## 작업 완료 내역

### 🏗️ 구조 및 설계
- **SVGR 설정 추가**: `svgr.config.js` 생성, 아이콘 색상 상속 처리 자동화
  - 기존 `fill`, `stroke` 속성 제거 및 `currentColor`로 대체
  - 아이콘이 부모 컴포넌트의 `color` 값을 따라가도록 설정

### 💄 스타일 설정
- **TabNavigation 아이콘 색상 정리**: SVG 아이콘이 외부 스타일을 따르도록 개선 (`currentColor` 적용)

---

## 주요 고민 및 해결과정

### 1. **SVG 색상 제어를 외부에서 자동화할 수 없을까?**

#### 🧐 **고민의 배경**

- SVGR을 사용하는 목적은 SVG를 React 컴포넌트로 래핑하여 재사용성과 스타일 적용을 쉽게 하려는 것이었습니다.
- 하지만 그동안은 SVG 파일을 직접 열어 `fill="currentColor"` 등의 수정을 수동으로 해야 했습니다.
- SVG 파일 수가 적을 땐 문제가 없었지만, 수십 개로 늘어나거나 다른 개발자와 협업할 경우 **파일 자체를 수정하는 방식은 비효율적**이라는 판단이 들었습니다.
- **외부 스타일로 색상을 제어할 수 있는 구조가 필요하다** 는 결론에 도달했고, SVGR 설정으로 이를 자동화할 방법을 찾게 되었습니다.
- 기존에는 SVGR을 단순히 변환 도구로만 사용했지만, 이번 기회에 그 기능을 제대로 이해하고 활용하고자 했습니다.

#### ⚙️ **적용한 방식**

- `svgr.config.js` 파일을 새로 만들어 SVGR 변환 시 다음과 같은 설정을 적용했습니다:

```js
export default {
  icon: true, // SVG를 아이콘처럼 1em 단위로 처리 (width/height 자동 비율 설정)

  expandProps: 'start', // React 컴포넌트의 props를 <svg {...props}>로 삽입할 위치 ('start'는 태그 시작 부분에 넣음)

  svgProps: {
    stroke: 'currentColor', // stroke 색상을 currentColor로 지정하여 CSS의 color 속성을 따라가게 함
    fill: 'currentColor', // fill 색상도 currentColor로 지정하여 외부에서 스타일 제어 가능하게 함
  },

  replaceAttrValues: {
    '#000': 'currentColor', // 하드코딩된 색상 #000을 currentColor로 치환
    '#000000': 'currentColor', // 하드코딩된 색상 #000000도 치환
    black: 'currentColor', // 문자열 'black'도 치환 (stroke="black" 같은 경우)
  },

  svgoConfig: {
    plugins: [
      {
        name: 'removeAttrs', // SVGO 플러그인: 특정 속성을 SVG에서 제거함
        params: {
          attrs: '(stroke|fill)', // 모든 stroke와 fill 속성을 제거하여 외부 스타일로 통제 가능하게 만듦
        },
      },
    ],
  },
};
```

- 핵심은 기존의 `fill`, `stroke` 속성을 제거한 후, 자동으로 `currentColor`로 대체되도록 설정한 것입니다.
- 이를 통해 부모 컴포넌트가 가진 `color` 값만 바꿔도 아이콘 색상이 반응하도록 만들었습니다.

#### ⚠️ **문제 발생: 아이콘 내부가 갑자기 채워짐**

- 설정 적용 후 일부 아이콘의 내부가 채워지는 이슈가 생겼습니다.
- 이는 SVG에서 `fill` 속성이 생기면, 닫힌 도형(`<path>`)의 내부가 기본 색상으로 채워지는 SVG의 동작 원리 때문이었습니다.
- 기존에는 `fill="none"`이거나 아예 `fill` 속성이 없었기에 비어 있었던 도형들이, `fill="currentColor"`를 갖게 되며 내부가 채워진 것입니다.


## 🔧 문제 원인

처음 설정은 다음과 같았습니다:

```js
svgProps: {
  stroke: 'currentColor',
  fill: 'currentColor',
}
```

이 설정은 **모든 SVG에 `stroke`와 `fill` 속성을 강제로 삽입**하게 됩니다.  
즉, `<path>`가 닫힌 도형일 경우 `fill="currentColor"`가 들어가며 **아이콘 내부가 의도치 않게 채워지는 부작용**이 발생했습니다.

---

## ✅ 최종 해결된 설정

```js
svgProps: {
  color: 'inherit', // 모든 SVG는 부모 color를 따르게
}
```

### 주요 변경 사항 비교

| 항목                  | 이전 설정                                             | 이후 설정                                                  |
|-----------------------|--------------------------------------------------------|---------------------------------------------------------------|
| `svgProps.fill`       | `'currentColor'` → 도형 내부가 예상치 않게 채워짐   | 제거됨 → `fill` 속성 강제 삽입 없음                        |
| `svgProps.stroke`     | `'currentColor'`                                       | 제거됨                                                     |
| `svgProps.color`      | 없음                                                   | `'inherit'` → 부모 color를 따라감                         |

---

## 해결

- SVG는 `fill`이 있으면 닫힌 도형 내부가 채워지는 특성이 있음
- `svgProps.fill`을 설정하면 모든 SVG에 `fill="currentColor"`가 들어가므로 내부가 채워짐
- 이를 제거하고 `color: 'inherit'`만 설정하면:
  - 외부에서 color만 제어할 수 있고
  - 도형 내부는 원래 의도대로 유지됨 (`fill="none"` 또는 비워진 상태)
  - SVGO 설정으로 기존 `fill`, `stroke` 속성은 제거됨


## 결론

> ❌ 문제의 원인:  
`svgProps.fill = "currentColor"`가 모든 도형에 적용되어 내부를 채우게 만듦

> ✅ 해결 방법:  
`fill`, `stroke`는 제거하고 `color: 'inherit'`만 설정하여  
**부모의 스타일을 따라가게 하고**, **도형 자체는 건드리지 않음**

이로써 예상치 못한 채움 현상이 사라지고,  
**SVG 아이콘의 색상을 외부에서 유연하게 제어할 수 있게 되었습니다.**

