### PR TITLE
✨ Feat : dropdown component

### DIFF
--- a/src/shared/components/Driver.jsx
+++ b/src/shared/components/Driver.jsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+const Divider = styled.div`
+  ${({
+    orientation = 'horizontal',
+    thickness = 1,
+    inset = 24,
+    color,
+    theme,
+  }) => {
+    const lineColor = color ?? theme.colors.neutralTextDefault;
+
+    if (orientation === 'horizontal') {
+      return css`
+        height: ${thickness}px;
+        background-color: ${lineColor};
+        margin: 0 ${inset}px;
+      `;
+    } else {
+      return css`
+        width: ${thickness}px;
+        background-color: ${lineColor};
+        margin: ${inset}px 0;
+      `;
+    }
+  }}
+`;
+
+export default Divider;

--- a/src/shared/components/Dropdown/Dropdown.jsx
+++ b/src/shared/components/Dropdown/Dropdown.jsx
@@ -11,43 +11,40 @@ const DropdownContainer = styled.div`
 `;
 
 function Dropdown({ items, selectedItem, onSelect, onAdd, renderItemAction }) {
-  const itemNodes = items.map((item) => (
-    <DropdownItem
-      key={item.id}
-      item={item}
-      isSelected={selectedItem?.id === item.id}
-      onClick={onSelect}
-      action={renderItemAction?.(item)}
-    />
-  ));
-
-  if (onAdd) {
-    itemNodes.push(
+  const itemNodes = items.flatMap((item, idx, arr) => {
+    const node = (
       <DropdownItem
-        key="__add__"
-        item={{ id: '__add__', name: '추가하기' }}
-        isSelected={false}
-        onClick={() => onAdd()}
+        key={item.id}
+        item={item}
+        isSelected={selectedItem?.id === item.id}
+        onClick={() => onSelect(item)}
+        action={renderItemAction?.(item)}
       />
     );
-  }
 
-  const nodesWithDividers = itemNodes.flatMap((node, idx, arr) => {
-    if (idx < arr.length - 1) {
-      return [
-        node,
-        <Driver
-          key={`div-${idx}`}
-          orientation="horizontal"
-          thickness={1}
-          inset={24}
-        />,
-      ];
-    }
-    return [node];
+    return idx < arr.length - 1
+      ? [node, <Driver key={`div-${item.id}`} inset={24} />]
+      : [node];
   });
 
-  return <DropdownContainer>{nodesWithDividers}</DropdownContainer>;
+  return (
+    <DropdownContainer>
+      {itemNodes}
+
+      {onAdd && (
+        <>
+          {items.length > 0 && <Driver key="div-add" inset={24} />}
+
+          <DropdownItem
+            key="__add__"
+            item={{ id: '__add__', name: '추가하기' }}
+            isSelected={false}
+            onClick={onAdd}
+          />
+        </>
+      )}
+    </DropdownContainer>
+  );
 }
 
 export default Dropdown;

--- a/src/shared/components/Dropdown/Dropdown.jsx
+++ b/src/shared/components/Dropdown/Dropdown.jsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+import Driver from '../Driver';
+import DropdownItem from './DropdownItem';
+
+const DropdownContainer = styled.div`
+  width: fit-content;
+  background-color: ${({ theme }) => theme.colors.neutralSurfaceDefault};
+  display: flex;
+  flex-direction: column;
+  border: 1px solid ${({ theme }) => theme.colors.neutralTextDefault};
+`;
+
+function Dropdown({ items, selectedItem, onSelect, onAdd, renderItemAction }) {
+  const itemNodes = items.map((item) => (
+    <DropdownItem
+      key={item.id}
+      item={item}
+      isSelected={selectedItem?.id === item.id}
+      onClick={onSelect}
+      action={renderItemAction?.(item)}
+    />
+  ));
+
+  if (onAdd) {
+    itemNodes.push(
+      <DropdownItem
+        key="__add__"
+        item={{ id: '__add__', name: '추가하기' }}
+        isSelected={false}
+        onClick={() => onAdd()}
+      />
+    );
+  }
+
+  const nodesWithDividers = itemNodes.flatMap((node, idx, arr) => {
+    if (idx < arr.length - 1) {
+      return [
+        node,
+        <Driver
+          key={`div-${idx}`}
+          orientation="horizontal"
+          thickness={1}
+          inset={24}
+        />,
+      ];
+    }
+    return [node];
+  });
+
+  return <DropdownContainer>{nodesWithDividers}</DropdownContainer>;
+}
+
+export default Dropdown;

--- a/src/shared/components/Dropdown/DropdownItem.jsx
+++ b/src/shared/components/Dropdown/DropdownItem.jsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+const ItemWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 24px;
+  color: ${({ isSelected, theme }) =>
+    isSelected ? theme.colors.pastelSeagull : theme.colors.neutralTextDefault};
+
+  ${({ theme }) => theme.typography.light12};
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.neutralSurfacePoint};
+  }
+`;
+
+const ItemLabel = styled.span`
+  display: inline-block;
+  width: 72px;
+`;
+
+export default function DropdownItem({ item, onClick, action, isSelected }) {
+  return (
+    <ItemWrapper isSelected={isSelected} onClick={() => onClick(item)}>
+      <ItemLabel>{item.name}</ItemLabel>
+      {action}
+    </ItemWrapper>
+  );
+}


### PR DESCRIPTION
## 작업 완료 내역

### ✨ 기능 추가
- **Driver 컴포넌트**: 수직·수평 마진을 props로 제어하고, 기본 테마 색상 지원  
- **Dropdown 컴포넌트**: 아이템 리스트 렌더링 및 “추가하기” 액션(optional) 지원  
- **DropdownItem 컴포넌트**: 개별 아이템 렌더링 및 onClick 핸들러 props 적용, Driver 컴포넌트로 아이템 간 구분선 처리  

### ♻️ 리팩토링
- **AddButton과 items 로직 분리**: Dropdown 내부에서 AddButton 로직을 별도 컴포넌트로 추출하고, 아이템 렌더링 책임을 분리  
## 주요 고민과 해결과정

### 1. 구분선 삽입 방식

#### 1.1 고민의 배경
- 드롭다운 항목 사이에만 가로 구분선을 그어야 하고,
- 패딩 영역을 침범하지 않으면서 hover 시 배경(full padding)을 유지해야 함.
- 같은 디자인이 입력 폼에도 필요하므로, **재사용 가능한** Divider 컴포넌트를 만들어 코드 응집도를 높이고 싶었음.

#### 1.2 고려했던 방식

| 방식                                      | 장점                                                         | 단점                                                                               |
|-----------------------------------------|------------------------------------------------------------|----------------------------------------------------------------------------------|
| CSS `:not(:last-child)` + `border-bottom` | 순수 CSS, JS 로직 불필요                                       | 패딩 영역까지 선이 그어지며 inset 조절 번거로움                                        |
| CSS `::after` pseudo-element            | `left`/`right`/`bottom` 오프셋으로 정확 제어                      | CSS 복잡도 증가, 토큰 결합 시 헷갈릴 수 있음                                           |
| **map + 조건부 (`idx < length - 1`)**      | JSX 안에서 직관적으로 “마지막만 제외” 처리                         | Fragment + 조건문이 많아지면 가독성 저하                                            |
| `allNodes.flatMap` interleave 패턴      | divider 삽입 로직이 한 군데 집중                                | flatMap 러닝 커브, footer와 섞이면 비즈니스 로직과 UI 흐름이 혼재될 수 있음             |
| 전용 `Divider` 컴포넌트                   | 수평·수직 커스터마이징, 완전 재사용 가능                         | 사용처가 한정되면 오버엔지니어링                                                      |

#### 1.3 최종 선택 및 이유
- **map + 조건부** 방식 선택
- 이유:
  1. 같은 **`Driver` 컴포넌트**를 입력 폼에도 재사용해야 해서 전용 컴포넌트를 분리했고,
  2. `flatMap` 방식은 footer(추가하기)와 섞이기 쉬워 비즈니스 로직과 UI 책임이 뒤섞일 우려가 있어,
  3. JSX 조건부 한 번으로 “마지막 아이템만 제외” 처리하는 것이 가장 명료하다고 판단했습니다.

---

### 2. 추가 아이템 처리

#### 2.1 고민의 배경
- 드롭다운 맨 아래에 “추가하기” 항목을 노출해야 하고,
- `onAdd` 플래그가 있을 때만 나타나야 함.
- 나중에 다른 footer 항목들이 늘어날 가능성도 염두에 두었으나, 현재는 “추가하기” 하나만 필요.

#### 2.2 고려했던 방식

| 방식                        | 장점                                                | 단점                                             |
|---------------------------|---------------------------------------------------|------------------------------------------------|
| `onAdd` 플래그 기반 자동 추가 | prop 하나로 간단 구현                                     | UI 로직(data shape)에 섞여 유지보수성 저하                |
| **`extraItem` 데이터 prop**    | JSX 오버헤드 없이 데이터만 전달, 최소 오버헤드                       | action/icon 등 추가 시 데이터 확장 필요               |
| `footer` JSX 슬롯 prop      | 부모에서 완전 커스텀 UI 전달, Dropdown 내부 수정 불필요           | prop이 늘어나고 한정적 사용 시 오버엔지니어링            |
| Compound Component (`<Dropdown.Footer>`) | 여러 슬롯 명시적 분리, 확장성 높음                                 | 러닝 커브, 단일 footer만 필요할 때 과도함              |
| JSX 최하단 분리 배치          | 비즈니스 로직과 UI 완전 분리                                | Fragment 사용, JSX가 길어질 수 있음                |

## 2.3 최종 선택 및 이유
- **JSX 최하단 분리 배치** 방식 선택  
- 이유:  
  1. 비즈니스 로직(`items.flatMap`)과 UI(`추가하기`) 블록이 완전히 분리되어 코드 응집도가 높아짐,  
  2. extraItem 또는 footer 슬롯 방식은 현재 “추가하기” 하나만 필요한 상황에선 오버엔지니어링이라 판단,  
  3. 가장 간단한 구현으로 YAGNI 원칙을 준수하며, 기획 변경 시 추후 가볍게 리팩터링하기 쉬운 구조를 확보.

