### PR TITLE
♻️ refactor : extract styled components & item actions

### DIFF
--- a/src/shared/components/Dropdown/AddButton.jsx
+++ b/src/shared/components/Dropdown/AddButton.jsx
@@ -1,0 +1,9 @@
+import { ItemWrapper, ItemLabel } from './ItemStyle';
+
+export default function AddButton({ label = '추가하기', onAdd }) {
+  return (
+    <ItemWrapper onClick={onAdd} isSelected={false}>
+      <ItemLabel>{label}</ItemLabel>
+    </ItemWrapper>
+  );
+}

--- a/src/shared/components/Dropdown/Dropdown.jsx
+++ b/src/shared/components/Dropdown/Dropdown.jsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import Driver from '../Driver';
 import DropdownItem from './DropdownItem';
+import AddButton from './AddButton';
 
 const DropdownContainer = styled.div`
   width: fit-content;
@@ -10,15 +11,15 @@ const DropdownContainer = styled.div`
   border: 1px solid ${({ theme }) => theme.colors.neutralTextDefault};
 `;
 
-function Dropdown({ items, selectedItem, onSelect, onAdd, renderItemAction }) {
+function Dropdown({ items, selectedItem, onSelect, onAdd, onDelete }) {
   const itemNodes = items.flatMap((item, idx, arr) => {
     const node = (
       <DropdownItem
         key={item.id}
         item={item}
         isSelected={selectedItem?.id === item.id}
-        onClick={() => onSelect(item)}
-        action={renderItemAction?.(item)}
+        onClick={onSelect}
+        onDelete={onDelete}
       />
     );
 
@@ -34,13 +35,7 @@ function Dropdown({ items, selectedItem, onSelect, onAdd, renderItemAction }) {
       {onAdd && (
         <>
           {items.length > 0 && <Driver key="div-add" inset={24} />}
-
-          <DropdownItem
-            key="__add__"
-            item={{ id: '__add__', name: '추가하기' }}
-            isSelected={false}
-            onClick={onAdd}
-          />
+          <AddButton key="__add__" onAdd={onAdd} />
         </>
       )}
     </DropdownContainer>

--- a/src/shared/components/Dropdown/DropdownItem.jsx
+++ b/src/shared/components/Dropdown/DropdownItem.jsx
@@ -1,32 +1,19 @@
-import styled from '@emotion/styled';
+import { ItemWrapper, ItemLabel } from './ItemStyle';
+import ItemRemoveButton from './ItemRemoveButton';
 
-const ItemWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 16px 24px;
-  color: ${({ isSelected, theme }) =>
-    isSelected ? theme.colors.pastelSeagull : theme.colors.neutralTextDefault};
-
-  ${({ theme }) => theme.typography.light12};
-
-  cursor: pointer;
-
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.neutralSurfacePoint};
-  }
-`;
-
-const ItemLabel = styled.span`
-  display: inline-block;
-  width: 72px;
-`;
-
-export default function DropdownItem({ item, onClick, action, isSelected }) {
+export default function DropdownItem({ item, onClick, onDelete, isSelected }) {
   return (
     <ItemWrapper isSelected={isSelected} onClick={() => onClick(item)}>
       <ItemLabel>{item.name}</ItemLabel>
-      {action}
+
+      {onDelete && (
+        <ItemRemoveButton
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(item.id);
+          }}
+        />
+      )}
     </ItemWrapper>
   );
 }

--- a/src/shared/components/Dropdown/ItemRemoveButton.jsx
+++ b/src/shared/components/Dropdown/ItemRemoveButton.jsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+import CloseSvg from '../../../assets/icons/closed.svg?react';
+
+const ItemRemoveButton = styled(CloseSvg)`
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  color: ${({ theme }) => theme.colors.dangerTextDefault};
+`;
+
+export default ItemRemoveButton;

--- a/src/shared/components/Dropdown/ItemStyle.jsx
+++ b/src/shared/components/Dropdown/ItemStyle.jsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+const ItemWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 24px;
+  ${({ theme }) => theme.typography.light12}
+  color: ${({ isSelected, theme }) =>
+    isSelected ? theme.colors.pastelSeagull : theme.colors.neutralTextDefault};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.surfacePoint};
+  }
+`;
+
+const ItemLabel = styled.span`
+  display: inline-block;
+  width: 72px;
+`;
+
+export { ItemWrapper, ItemLabel };


### PR DESCRIPTION
## 작업 완료 내역

### ✨ 기능 추가
- **`AddButton` 컴포넌트**  
  - `DropdownItem`에서 분리하여 독립적으로 구현  
  - 비즈니스 로직(추가하기)만 담당하도록 역할 한정  
- **`CloseButton` 컴포넌트**  
  - 삭제 버튼 전용 컴포넌트로 추출  
  - `onDelete(id)` 콜백만 받아 내부에서 X 아이콘 조건부 렌더링  

### ♻️ 리팩토링
- **공통 스타일 분리**  
  - `ItemWrapper` / `ItemLabel`을 styled 컴포넌트로 추출  
  - 재사용성과 응집도 향상으로 스타일 변경 시 유지보수 간소화  
- **내부 바인딩 방식 변경**  
  - 부모에서 클로저를 넘기지 않고, 컴포넌트 내부에서 `onClick(item)` / `onDelete(id)` 형태로 바인딩  
- **삭제 로직 간소화**  
  - `renderItemAction` 프로퍼티 제거  
  - `onDelete(id)`만으로 삭제 기능 처리  

---
### Dropdown 컴포넌트 사용법

공통 드롭다운 UI를 재사용할 수 있도록 만든 컴포넌트입니다. 아래 예시처럼 사용합니다.

```jsx
import { useState } from 'react';
import Dropdown from '../shared/components/Dropdown/Dropdown';

function Example() {
  const [selected, setSelected] = useState({});
  const [open, setOpen] = useState(false);

  const items = [
    { id: '1', name: '옵션 A' },
    { id: '2', name: '옵션 B' },
  ];

  return (
    <>
      <div>{selected.name || '선택하세요'}</div>
      <button onClick={() => setOpen(!open)}>열기</button>

      {open && (
        <Dropdown
          selectedItem={selected}
          items={items}
          onSelect={setSelected}
          onAdd={() => console.log('추가')}
          onDelete={(id) => console.log('삭제', id)}
        />
      )}
    </>
  );
}
```

#### Dropdown Props

| Prop           | Type       | Description                              |
|----------------|------------|------------------------------------------|
| `selectedItem` | `object`   | 현재 선택된 항목                         |
| `items`        | `array`    | 드롭다운에 표시할 항목 리스트            |
| `onSelect`     | `function` | 항목을 선택했을 때 호출 (`item` 전달됨) |
| `onAdd`        | `function` | "추가" 버튼 클릭 시 호출                 |
| `onDelete`     | `function` | 항목 삭제 시 호출 (`id` 전달됨)         |

---

## 주요 고민 및 해결과정

### 1. **비즈니스 로직과 UI 로직을 어떻게 분리할까?**

#### 🧐 고민의 배경
- `DropdownItem` 하나에 추가·삭제 기능이 모두 섞여 있어 컴포넌트 복잡도가 증가  
- 각 기능의 시그니처(`onAdd()` vs `onDelete(id)`)가 달라 유지보수가 어려움  

#### **고려한 방식**
1. **단일 컴포넌트 유지**  
   - `renderItemAction` 등 props API를 확장해 분기 처리  
   - 하지만 props가 많아지고 사용법이 복잡해짐  
2. **부모에서 로직 분기**  
   - 상위에서 추가/삭제 핸들러를 모두 넘겨 분기 처리  
   - 부모 책임이 과도해지고 컴포넌트 재사용성이 저하  
3. **컴포넌트 분리**  
   - 역할에 따라 `AddButton`과 `CloseButton`을 분리  
   - 공통 스타일만 공유해 응집도는 유지  

#### ✅ 최종 해결
- **기능별 컴포넌트 분리**  
  - `AddButton`은 추가 로직만, `CloseButton`은 삭제 로직만 담당  
  - 공통 스타일(`ItemWrapper`/`ItemLabel`)만 재사용해 코드 응집도·확장성 확보  

---

### 2. **Props API를 어떻게 단순화할까?**

#### 🧐 고민의 배경
- 초기 설계 시 `renderItemAction`, `extraItem` 등 다양한 props를 지원하도록 설계  
- 현재는 ‘추가하기’와 ‘삭제’ 두 가지 기능만 필요해 과도한 API가 오히려 복잡함  

#### **고려한 방식**
1. **기존 API 유지**  
   - 다양한 시나리오에 대응할 수 있으나 사용법이 직관적이지 않음  
2. **필요없는 Props 제거**  
   - YAGNI 원칙에 따라 실제 사용되지 않는 props 제거  
3. **핵심 기능만 남기기**  
   - `onClick(item)`과 `onDelete(id)` 콜백 중심으로 API 재정리  

#### ✅ 최종 해결
- `renderItemAction`, `extraItem` 등 불필요한 props를 모두 제거  
- API 단순화로 사용법 직관화 및 유지보수 편의성 강화  