### PR TITLE
♻️✨🐛 Streamline modals & payment methods, refine delete logic & fix hover bug

### DIFF
--- a/src/context/modalProvider.jsx
+++ b/src/context/modalProvider.jsx
@@ -1,39 +1,23 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import ReactDOM from 'react-dom';
-import Modal from '../shared/components/Modal';
+
 import ModalContext from './modalContext';
 
-const initialState = {
-  isOpen: false,
-  title: '',
-  content: null,
-  action: {},
-};
-
 const ModalProvider = ({ children }) => {
-  const [modalState, setModalState] = useState(initialState);
+  const [modalNode, setModalNode] = useState(null);
 
-  const openModal = ({ title, content, action }) => {
-    setModalState({ isOpen: true, title, content, action });
-  };
-
-  const closeModal = () => {
-    setModalState(initialState);
-  };
+  const openModal = useCallback((node) => {
+    setModalNode(node);
+  }, []);
+  const closeModal = useCallback(() => {
+    setModalNode(null);
+  }, []);
 
   return (
     <ModalContext.Provider value={{ openModal, closeModal }}>
       {children}
-      {modalState.isOpen &&
-        ReactDOM.createPortal(
-          <Modal
-            title={modalState.title}
-            content={modalState.content}
-            action={modalState.action}
-            onClose={closeModal}
-          />,
-          document.getElementById('modal-root')
-        )}
+      {modalNode &&
+        ReactDOM.createPortal(modalNode, document.getElementById('modal-root'))}
     </ModalContext.Provider>
   );
 };

--- a/src/features/form/components/modals/AddPaymentMethodModal.jsx
+++ b/src/features/form/components/modals/AddPaymentMethodModal.jsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import Modal from '../../../../shared/components/Modal';
+import TextInput from '../../../../shared/components/TextInput';
+
+const ADD_MODAL_CONFIG = {
+  title: '추가하실 결제 수단을 입력해주세요.',
+  placeholder: 'ex: 완자 카드',
+  action: {
+    label: '추가',
+    variant: 'emphasized',
+  },
+};
+
+export default function AddInputModalContent({ onSubmit, onClose }) {
+  const [value, setValue] = useState('');
+
+  const { title, placeholder, action } = ADD_MODAL_CONFIG;
+
+  return (
+    <Modal
+      title={title}
+      action={{
+        label: action.label,
+        onClick: () => onSubmit(value),
+        variant: action.variant,
+        disabled: value.length === 0,
+      }}
+      onClose={onClose}
+    >
+      <TextInput
+        value={value}
+        placeholderText={placeholder}
+        onChange={setValue}
+      />
+    </Modal>
+  );
+}

--- a/src/features/form/components/modals/DeletePaymentMethodModal.jsx
+++ b/src/features/form/components/modals/DeletePaymentMethodModal.jsx
@@ -1,0 +1,29 @@
+import Modal from '../../../../shared/components/Modal';
+import TextInput from '../../../../shared/components/TextInput';
+
+const DELETE_MODAL_CONFIG = {
+  title: '해당 결제 수단을 삭제하시겠습니까?',
+  action: {
+    label: '삭제',
+    variant: 'danger',
+  },
+};
+
+export default function DeleteModalContent({ targetItem, onSubmit, onClose }) {
+  const { title, action } = DELETE_MODAL_CONFIG;
+
+  return (
+    <Modal
+      title={title}
+      action={{
+        label: action.label,
+        onClick: () => onSubmit(targetItem),
+        variant: action.variant,
+        disabled: !targetItem,
+      }}
+      onClose={onClose}
+    >
+      <TextInput value={targetItem.name} disabled={true} />
+    </Modal>
+  );
+}

--- a/src/shared/components/Dropdown/DropdownItem.jsx
+++ b/src/shared/components/Dropdown/DropdownItem.jsx
@@ -10,7 +10,7 @@ export default function DropdownItem({ item, onClick, onDelete, isSelected }) {
         <ItemRemoveButton
           onClick={(e) => {
             e.stopPropagation();
-            onDelete(item.id);
+            onDelete(item);
           }}
         />
       )}

--- a/src/shared/components/Dropdown/ItemStyle.jsx
+++ b/src/shared/components/Dropdown/ItemStyle.jsx
@@ -11,7 +11,7 @@ const ItemWrapper = styled.div`
   cursor: pointer;
 
   &:hover {
-    background-color: ${({ theme }) => theme.colors.surfacePoint};
+    background-color: ${({ theme }) => theme.colors.neutralSurfacePoint};
   }
 `;
 

--- a/src/shared/components/Modal.jsx
+++ b/src/shared/components/Modal.jsx
@@ -62,21 +62,23 @@ const ModalActions = styled.div`
 const Button = styled.button`
   width: 100%;
   padding: 16px 0;
-  color: ${({ variant = 'emphasized', theme }) =>
-    theme.colors[colorMap[variant]]};
+  color: ${({ variant = 'emphasized', disabled, theme }) =>
+    disabled
+      ? theme.colors[colorMap['weak']]
+      : theme.colors[colorMap[variant]]};
 
   ${({ theme }) => theme.typography.semibold16};
 
   background-color: ${({ theme }) => theme.colors.neutralSurfaceDefault};
 `;
 
-const Modal = ({ title, content, action, onClose }) => {
+const Modal = ({ title, children, action, onClose }) => {
   return (
     <ModalOverlay>
       <ModalContainer>
         <ModalContents>
           <ModalTitle>{title}</ModalTitle>
-          {content}
+          {children}
         </ModalContents>
         <ModalActions>
           <Button key="cancle" onClick={onClose} variant="weak">

--- a/src/shared/components/TextInput.jsx
+++ b/src/shared/components/TextInput.jsx
@@ -32,11 +32,18 @@ export default function TextInput({
         ? 'active'
         : 'enabled';
 
+  const handleChange = (e) => {
+    if (onChange) {
+      onChange(e.target.value);
+    }
+  };
+
   return (
     <Wrapper type={type} visualState={visualState}>
       <StyledInput
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        readOnly={!onChange}
+        onChange={handleChange}
         placeholder={placeholderText}
         disabled={disabled}
         onFocus={() => setIsFocused(true)}


### PR DESCRIPTION
## 작업 완료 내역

### ✨ 기능 추가
- **페이먼트 모달 추가**: `AddPaymentMethodModal` 및 `DeletePaymentMethodModal` 생성, 제목·플레이스홀더·액션 설정을 상수로 분리  
- **DropDownItem 삭제 로직 개선**: `onDelete` 파라미터로 `item` 객체(id, name)를 전달하도록 변경

### ♻️ 리팩토링
- **ModalProvider 역할 분리**: openModal에 JSX node를 전달받아 포털로 렌더링만 수행하도록 설계 변경
- **커스텀 모달 컴포넌트 도입**: 공용 Modal 컴포넌트를 감싸는 AddInputModal, ConfirmDeleteModal 등 컴포넌트 생성
- **openModal API 단순화**: `openModal(<MyCustomModal prop1={…} />)` 형태로 호출부 가독성과 유연성 향상

### 🐛 버그 수정
- **InputText 상태 갱신 버그 해결**: 기존 클로저 기반 렌더링으로 인한 “스냅샷” 문제 제거
- **드롭다운 호버 색상 테마 키 수정**: theme 객체 키 오타 수정으로 호버 색상 정상 적용

## 주요 고민 및 해결과정

### 1. **InputText 상태 고정(스냅샷) 버그 발생 원인**

#### 🧐 고민의 배경
- 공용 Modal에 `content: <InputText />` JSX만 넘겨 클로저로 상태를 관리할 때, 모달이 한 번 렌더링된 후에는 클로저가 스냅샷처럼 고정되어 state가 갱신되지 않는 문제 발생
- 사용자가 입력해도 onChange로 넘어간 값이 갱신되지 않아 input이 업데이트되지 않는 버그

#### 고려했던 수정 방식
1. **renderContent 콜백 사용**  
   - `openModal({ renderContent: () => <InputText …/> })` 형태로 매번 새로운 JSX 생성  
   - 단점:  
     - API 복잡도 증가: 객체 스펙 확대 및 콜백 함수 생성 필요  
     - 호출부 가독성 저하: JSX가 콜백 안에 숨어 구조 파악 어려움  
     - 확장성 제한: `renderHeader`, `renderFooter` 등 추가 분기 시 ModalProvider 내부 로직 비대화

### 2. **최종 설계 선택: JSX 전달 방식**

#### ✅ 해결 방안 및 판단 이유
- **역할 분리**  
  - `ModalProvider`: 받은 JSX node를 modal-root에 포털로 띄우는 역할만 담당  
  - **공용 Modal**: Overlay/Header/Body/Footer 같은 레이아웃 제공  
  - **커스텀 모달 컴포넌트**: 내부 로직·state·버튼 액션 직접 관리
- **유연성·재사용성 확보**  
  - 호출부에서는 `openModal(<MyCustomModal …/>)` 한 줄로 원하는 모달 렌더링  
  - 신규 모달 추가 시 ModalProvider 변경 불필요, 공용 Modal만 감싸는 컴포넌트 작성
- **버그 해소 및 가독성 개선**  
  - 호출부에서 직접 렌더링되므로 InputText의 state가 항상 최신 렌더 사이클 반영  
  - API 단순화로 호출부 JSX만 보면 모달 구조·내용 직관적 이해 가능

## 결론

“ModalProvider는 어떤 모달을 보여줄지 판단하지 않고, 받은 JSX를 포털로 띄우기만 한다.”
이를 통해 스냅샷 이슈 없이 input state가 올바르게 반영되고, API가 단순해져 가독성이 개선되며, 모달 로직·레이아웃·표시 책임이 명확하게 분리되어 유지보수성과 확장성이 모두 향상되었습니다.
